### PR TITLE
Feat go back button

### DIFF
--- a/src/components/goBack/goBack.tsx
+++ b/src/components/goBack/goBack.tsx
@@ -25,6 +25,8 @@ export default class GoBack extends React.Component<GoBackProps, any> {
         }
     }
 
+    static GoBackButton: typeof import('./goBackButton').default
+
     getButtonView () {
         const { style } = this.props;
 

--- a/src/components/goBack/goBackButton.tsx
+++ b/src/components/goBack/goBackButton.tsx
@@ -2,14 +2,22 @@ import * as React from 'react'
 import { Button } from 'antd'
 import { browserHistory, hashHistory } from 'react-router'
 
-export default class GoBackButton extends React.Component<any, any> {
+export interface GoBackButtonProps {
+    title?: string;
+    url?: string;
+    autoClose?: boolean;
+    style?: React.CSSProperties;
+    history?: any;
+}
+
+export default class GoBackButton extends React.Component<GoBackButtonProps, any> {
     go = () => {
         const { url, history, autoClose } = this.props
 
         if (url) {
             if (history) { browserHistory.push(url) } else { hashHistory.push(url) }
         } else {
-            if (window.history.length == 1) {
+            if (window.history?.length == 1) {
                 if (autoClose) {
                     window.close();
                 }

--- a/src/components/goBack/goBackButton.tsx
+++ b/src/components/goBack/goBackButton.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { Button } from 'antd'
+import { browserHistory, hashHistory } from 'react-router'
+
+export default class GoBackButton extends React.Component<any, any> {
+    go = () => {
+        const { url, history, autoClose } = this.props
+
+        if (url) {
+            if (history) { browserHistory.push(url) } else { hashHistory.push(url) }
+        } else {
+            if (window.history.length == 1) {
+                if (autoClose) {
+                    window.close();
+                }
+            } else {
+                hashHistory.go(-1);
+            }
+        }
+    }
+
+    render () {
+        const { title } = this.props
+        return (
+            <Button {...this.props} onClick={this.go}>{title || '返回' }</Button>
+        )
+    }
+}

--- a/src/components/goBack/goBackIcon.tsx
+++ b/src/components/goBack/goBackIcon.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Icon } from 'antd/lib'
+import { browserHistory, hashHistory } from 'react-router'
+
+export interface GoBackProps {
+    url?: string;
+    autoClose?: boolean;
+    style?: React.CSSProperties;
+    history?: boolean;
+}
+export default class GoBack extends React.Component<GoBackProps, any> {
+    go = () => {
+        const { url, history, autoClose } = this.props
+
+        if (url) {
+            if (history) { browserHistory.push(url) } else { hashHistory.push(url) }
+        } else {
+            if (window.history.length == 1) {
+                if (autoClose) {
+                    window.close();
+                }
+            } else {
+                hashHistory.go(-1);
+            }
+        }
+    }
+
+    getButtonView () {
+        const { style } = this.props;
+
+        let iconStyle: React.CSSProperties = {
+            cursor: 'pointer',
+            fontFamily: 'anticon',
+            fontSize: '18px',
+            color: 'rgb(148, 168, 198)',
+            letterSpacing: '5px',
+            position: 'relative',
+            top: '2px'
+        }
+
+        if (style) {
+            iconStyle = Object.assign(iconStyle, style)
+        }
+
+        return (
+            <Icon
+                style={iconStyle}
+                type={'left-circle-o'}
+                onClick={this.go}
+            />
+        )
+    }
+
+    render () {
+        return this.getButtonView();
+    }
+}

--- a/src/components/goBack/index.tsx
+++ b/src/components/goBack/index.tsx
@@ -1,57 +1,9 @@
-import React from 'react'
-import { Icon } from 'antd/lib'
-import { browserHistory, hashHistory } from 'react-router'
+import GoBackIcon from './goBackIcon'
+import GoBackButton from './goBackButton'
 
-export interface GoBackProps {
-    url?: string;
-    autoClose?: boolean;
-    style?: React.CSSProperties;
-    history?: boolean;
+export {
+    GoBackIcon,
+    GoBackButton
 }
-export default class GoBack extends React.Component<GoBackProps, any> {
-    go = () => {
-        const { url, history, autoClose } = this.props
 
-        if (url) {
-            if (history) { browserHistory.push(url) } else { hashHistory.push(url) }
-        } else {
-            if (window.history.length == 1) {
-                if (autoClose) {
-                    window.close();
-                }
-            } else {
-                hashHistory.go(-1);
-            }
-        }
-    }
-
-    getButtonView () {
-        const { style } = this.props;
-
-        let iconStyle: React.CSSProperties = {
-            cursor: 'pointer',
-            fontFamily: 'anticon',
-            fontSize: '18px',
-            color: 'rgb(148, 168, 198)',
-            letterSpacing: '5px',
-            position: 'relative',
-            top: '2px'
-        }
-
-        if (style) {
-            iconStyle = Object.assign(iconStyle, style)
-        }
-
-        return (
-            <Icon
-                style={iconStyle}
-                type={'left-circle-o'}
-                onClick={this.go}
-            />
-        )
-    }
-
-    render () {
-        return this.getButtonView();
-    }
-}
+export default GoBackIcon

--- a/src/components/goBack/index.tsx
+++ b/src/components/goBack/index.tsx
@@ -1,9 +1,5 @@
-import GoBackIcon from './goBackIcon'
+import GoBack from './goBack'
 import GoBackButton from './goBackButton'
 
-export {
-    GoBackIcon,
-    GoBackButton
-}
-
-export default GoBackIcon
+GoBack.GoBackButton = GoBackButton
+export default GoBack

--- a/src/stories/goBack.stories.tsx
+++ b/src/stories/goBack.stories.tsx
@@ -4,7 +4,9 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { PropsTable } from './components/propsTable';
 import ExampleContainer from './components/exampleCode';
-import GoBack, { GoBackButton } from '../components/goBack';
+import GoBack from '../components/goBack';
+
+const { GoBackButton } = GoBack
 
 const stories = storiesOf('GoBack 返回', module);
 stories.addDecorator(withKnobs);

--- a/src/stories/goBack.stories.tsx
+++ b/src/stories/goBack.stories.tsx
@@ -1,50 +1,99 @@
-import React from 'react'
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { withKnobs } from '@storybook/addon-knobs';
 import { PropsTable } from './components/propsTable';
 import ExampleContainer from './components/exampleCode';
-import GoBack from '../components/goBack';
+import GoBack, { GoBackButton } from '../components/goBack';
 
 const stories = storiesOf('GoBack 返回', module);
-stories.addDecorator(withKnobs)
+stories.addDecorator(withKnobs);
 
-const propDefinitions = [{
-    property: 'url',
-    propType: 'string',
-    required: false,
-    description: '返回的路由， 如不传参数，则默认返回浏览器上一级url',
-    defaultValue: ''
-}, {
-    property: 'autoClose',
-    propType: 'boolean',
-    required: false,
-    description: '是否关闭浏览器窗口',
-    defaultValue: 'false'
-}]
-const otherDependencies = `import { GoBack } from 'dt-react-component';`
-const code = `<GoBack />`
-
-stories.add('goback', () => {
-    return (
-        <div className='story_wrapper'>
-            <h2>何时使用</h2>
-            <p>返回匹配的路由， 默认返回浏览器上一级路由</p>
-            <h2>示例</h2>
-            <p>点击我试试看</p>
-            <ExampleContainer otherDependencies={otherDependencies} code={code} hasCodeSandBox={true}>
-                <GoBack />
-            </ExampleContainer>
-        </div>
-    )
-}, {
-    info: {
-        text: `
-            代码示例：
-            ~~~js
-            <GoBack url='/api/manage' />
-            ~~~
-        `,
-        TableComponent: () => PropsTable({ propDefinitions })
+const propDefinitions = [
+    {
+        property: 'url',
+        propType: 'string',
+        required: false,
+        description: '返回的路由， 如不传参数，则默认返回浏览器上一级url',
+        defaultValue: ''
+    },
+    {
+        property: 'autoClose',
+        propType: 'boolean',
+        required: false,
+        description: '是否关闭浏览器窗口',
+        defaultValue: 'false'
     }
-})
+];
+
+
+const propButtonDefinitions = [
+    {
+        property: 'title',
+        propType: 'string',
+        required: false,
+        description: '显示文字',
+        defaultValue: '返回'
+    }
+];
+
+const otherDependencies = `import { GoBack } from 'dt-react-component';`;
+const code = `<GoBack />`;
+const buttonDependencies = `import { GoBack } from 'dt-react-component';\nconst { GoBackButton } = GoBack`;
+const buttonCode = `<GoBackButton />`;
+
+stories
+    .add(
+        'goBack',
+        () => {
+            return (
+                <div className="story_wrapper">
+                    <h2>何时使用</h2>
+                    <p>返回匹配的路由， 默认返回浏览器上一级路由</p>
+                    <h2>示例</h2>
+                    <p>点击我试试看</p>
+                    <ExampleContainer otherDependencies={otherDependencies} code={code} hasCodeSandBox={true}>
+                        <GoBack />
+                    </ExampleContainer>
+                </div>
+            );
+        },
+        {
+            info: {
+                text: `
+                    代码示例：
+                    ~~~js
+                    <GoBack url='/api/manage' />
+                    ~~~
+                `,
+                TableComponent: () => PropsTable({ propDefinitions })
+            }
+        }
+    )
+    .add(
+        'goBackButton',
+        () => {
+            return (
+                <div className="story_wrapper">
+                    <h2>何时使用</h2>
+                    <p>返回匹配的路由， 默认返回浏览器上一级路由</p>
+                    <h2>示例</h2>
+                    <p>点击我试试看</p>
+                    <ExampleContainer otherDependencies={buttonDependencies} code={buttonCode} hasCodeSandBox={true}>
+                        <GoBackButton />
+                    </ExampleContainer>
+                </div>
+            );
+        },
+        {
+            info: {
+                text: `
+                    代码示例：
+                    ~~~js
+                    <GoBackButton title='返回上一级页面' />
+                    ~~~
+                `,
+                TableComponent: () => PropsTable({ propDefinitions: propButtonDefinitions })
+            }
+        }
+    );

--- a/src/stories/goBack.stories.tsx
+++ b/src/stories/goBack.stories.tsx
@@ -26,7 +26,6 @@ const propDefinitions = [
     }
 ];
 
-
 const propButtonDefinitions = [
     {
         property: 'title',


### PR DESCRIPTION
从 `dt-common` 迁移组件 `goBackButton`

基于原先的`goBack`组件
```
import GoBackIcon from './goBackIcon'
import GoBackButton from './goBackButton'

export {
    GoBackIcon,
    GoBackButton
}

export default GoBackIcon
```

![image](https://user-images.githubusercontent.com/46592356/128331958-81ec8608-5adc-40ee-9823-716122881e15.png)
