### PR TITLE
Feat 2.0.6 modalwith form

### DIFF
--- a/src/components/modalWithForm/index.tsx
+++ b/src/components/modalWithForm/index.tsx
@@ -5,7 +5,7 @@ import { ButtonProps, ButtonType } from 'antd/lib/button';
 
 export interface ModalProps {
     hideModelHandler: () => any;
-    onSubmit: (values: any, record: any) => void;
+    onSubmit?: (values: any, record: any) => void;
     cancelText?: string;
     okText?: string;
     okType?: ButtonType;

--- a/src/components/modalWithForm/index.tsx
+++ b/src/components/modalWithForm/index.tsx
@@ -18,6 +18,7 @@ export interface ModalProps {
     footer?: string | React.ReactNode;
     centered?: boolean;
     cancelButtonProps?: ButtonProps;
+    notSubmitCloseModal?: boolean;
 }
 
 function ModalWithForm (FormComponent: any) {
@@ -26,11 +27,11 @@ function ModalWithForm (FormComponent: any) {
             super(props);
         }
         okHandler = () => {
-            const { record, onSubmit, hideModelHandler } = this.props;
+            const { record, notSubmitCloseModal = false, onSubmit, hideModelHandler } = this.props;
             this.props.form.validateFields((err: any, values: any) => {
                 if (!err) {
                     onSubmit(values, record);
-                    hideModelHandler();
+                    !notSubmitCloseModal && hideModelHandler();
                 }
             });
         };

--- a/src/stories/modalWithForm.stories.tsx
+++ b/src/stories/modalWithForm.stories.tsx
@@ -17,7 +17,7 @@ const propDefinitions = [
     }, {
         property: 'onSubmit',
         propType: 'Function',
-        required: true,
+        required: false,
         description: '点击确定按钮后，表单的值验证无误后的回调，接受两个参数value:表单的值，record:其他想要提交的值',
         defaultValue: '--'
     }, {

--- a/src/stories/modalWithForm.stories.tsx
+++ b/src/stories/modalWithForm.stories.tsx
@@ -98,6 +98,12 @@ const propDefinitions = [
         required: false,
         description: 'cancel 按钮 props',
         defaultValue: '--'
+    }, {
+        property: 'notSubmitCloseModal',
+        propType: 'Boolean',
+        require: false,
+        description: '禁止提交后自动关闭modal',
+        defaultValue: 'false'
     }
 ]
 


### PR DESCRIPTION
1.增加notSubmitCloseModal API，禁止提交后自动关闭modal，默认为false
2. onSubmit设置为可选参数，当footer为null时不存在提交按钮的事件
#118 