### PR TITLE
Feat search modal

### DIFF
--- a/src/components/searchModal/index.tsx
+++ b/src/components/searchModal/index.tsx
@@ -1,79 +1,57 @@
-import React from 'react'
+import React from 'react';
 
-import { Modal, AutoComplete, Input, Row, Col, Select } from 'antd';
+import { Modal, AutoComplete, Input, Row, Col } from 'antd';
 
-const Option = Select.Option;
-const TASK_STATUS = {
-    TASKDESC: 1,
-    TASKNAME: 2
-}
 export interface SearchModalProps {
     visible: boolean;
-    name?: 'notebook';
-    title?: string;
-    onChange?: (value: string, callback: Function, search?: typeof TASK_STATUS) => void;
-    onSelect?: (value: string) => void;
+    dataSource: any[];
+    title?: string | null;
+    placeholder?: string;
+    prefixRender?: React.ReactDOM;
+    onChange?: (value: string) => void;
+    onSelect?: (value: string, option: Object) => void;
     onCancel?: () => void;
     [propName: string]: any;
 }
 class SearchModal extends React.Component<SearchModalProps, any> {
-    state: any = {
-        data: [],
-        search: TASK_STATUS.TASKNAME
-    }
     onCancel = () => {
         this.props.onCancel();
-    }
+    };
+
     onChange = (value: any) => {
         const { onChange } = this.props;
-        const { search } = this.state;
-        if (onChange) {
-            onChange(value, this.changeValue, search)
-        }
-    }
-    searchTask (value: number) {
-        this.setState({ search: value })
-    }
-    onSelect = (value: any) => {
-        this.props.onSelect(value);
-    }
-    changeValue = (values: any) => {
-        this.setState({
-            data: values
-        })
-    }
-    render () {
-        const { data, search } = this.state;
-        const { visible, title, name } = this.props;
+        onChange?.(value);
+    };
+
+    onSelect = (value: any, option: Object) => {
+        this.props?.onSelect(value, option);
+    };
+
+    render() {
+        const { visible, title = '搜索并打开', prefixRender, dataSource = [], bodyStyle,placeholder = '请输入', ...other } = this.props;
         return (
             <Modal
+                {...other}
                 visible={visible}
                 onCancel={this.onCancel}
                 footer={null}
-                title={title || '搜索并打开'}
+                title={title}
             >
                 <Row align="middle" justify="center" type="flex">
-                    { name === 'notebook' && (
-                        <Col span={6} >
-                            <Select style={{ width: '100%', marginTop: '4px' }} value={search} onChange={this.searchTask.bind(this)}>
-                                <Option value={TASK_STATUS.TASKNAME}>任务名称</Option>
-                                <Option value={TASK_STATUS.TASKDESC}>任务描述</Option>
-                            </Select>
-                        </Col>)
-                    }
-                    <Col span={name === 'notebook' ? 18 : 24}>
+                    {prefixRender && <Col span={6} style={{paddingRight: '12px'}}>{prefixRender}</Col>}
+                    <Col span={prefixRender ? 18 : 24}>
                         <AutoComplete
-                            dataSource={data}
-                            style={{ width: '100%', height: '28px', margin: '8px 0' }}
+                            dataSource={dataSource}
+                            style={{ width: '100%', margin: '8px 0' }}
                             onSelect={this.onSelect}
                             onSearch={this.onChange}
                         >
-                            <Input.Search style={{ marginLeft: '8px' }}/>
+                            <Input.Search placeholder={placeholder} />
                         </AutoComplete>
                     </Col>
                 </Row>
             </Modal>
-        )
+        );
     }
 }
 export default SearchModal;

--- a/src/components/searchModal/index.tsx
+++ b/src/components/searchModal/index.tsx
@@ -7,7 +7,7 @@ export interface SearchModalProps {
     dataSource: any[];
     title?: string | null;
     placeholder?: string;
-    prefixRender?: React.ReactDOM;
+    prefixRender?: React.ReactNode;
     onChange?: (value: string) => void;
     onSelect?: (value: string, option: Object) => void;
     onCancel?: () => void;

--- a/src/components/searchModal/index.tsx
+++ b/src/components/searchModal/index.tsx
@@ -28,17 +28,23 @@ class SearchModal extends React.Component<SearchModalProps, any> {
     };
 
     render() {
-        const { visible, title = '搜索并打开', prefixRender, dataSource = [], bodyStyle,placeholder = '请输入', ...other } = this.props;
+        const {
+            visible,
+            title = '搜索并打开',
+            prefixRender,
+            dataSource = [],
+            bodyStyle,
+            placeholder = '请输入',
+            ...rest
+        } = this.props;
         return (
-            <Modal
-                {...other}
-                visible={visible}
-                onCancel={this.onCancel}
-                footer={null}
-                title={title}
-            >
+            <Modal {...rest} visible={visible} onCancel={this.onCancel} footer={null} title={title}>
                 <Row align="middle" justify="center" type="flex">
-                    {prefixRender && <Col span={6} style={{paddingRight: '12px'}}>{prefixRender}</Col>}
+                    {prefixRender && (
+                        <Col span={6} style={{ paddingRight: '12px' }}>
+                            {prefixRender}
+                        </Col>
+                    )}
                     <Col span={prefixRender ? 18 : 24}>
                         <AutoComplete
                             dataSource={dataSource}

--- a/src/stories/searchModal.stories.tsx
+++ b/src/stories/searchModal.stories.tsx
@@ -40,7 +40,7 @@ const propDefinitions = [
     },
     {
         property: 'prefixRender',
-        propType: 'ReactDOM',
+        propType: 'ReactNode',
         required: false,
         description: '自定义DOM前缀',
         defaultValue: '搜索并打开'

--- a/src/stories/searchModal.stories.tsx
+++ b/src/stories/searchModal.stories.tsx
@@ -1,36 +1,66 @@
-import React from 'react'
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import SearchModal from '../components/searchModal';
-import { Button } from 'antd';
+import { Button, Select } from 'antd';
 import { State, Store } from '@sambego/storybook-state';
 import { PropsTable } from './components/propsTable';
 import ExampleContainer from './components/exampleCode';
 import '../styles/index.scss';
 
+const { Option } = Select;
+const initDataSource = ['gmail.com', '163.com', 'qq.com'];
+
 const store = new Store({
     visible: false,
+    visible1: false,
+    dataSource: initDataSource,
     key: Math.random()
-})
-const propDefinitions = [{
-    property: 'title',
-    propType: 'string',
-    required: false,
-    description: 'modal 标题',
-    defaultValue: '搜索并打开'
-}, {
-    property: '其余属性',
-    propType: '--',
-    required: false,
-    description: '继承 Antd Modal、AutoComplete API',
-    defaultValue: ''
-}]
+});
+const propDefinitions = [
+    {
+        property: 'title',
+        propType: 'string',
+        required: false,
+        description: 'modal 标题',
+        defaultValue: '搜索并打开'
+    },
+    {
+        property: 'dataSource',
+        propType: 'Array',
+        required: true,
+        description: '自定义DOM前缀',
+        defaultValue: '【】'
+    },
+    {
+        property: 'placeholder',
+        propType: 'string',
+        required: false,
+        description: '搜索框提示信息',
+        defaultValue: ''
+    },
+    {
+        property: 'prefixRender',
+        propType: 'ReactDOM',
+        required: false,
+        description: '自定义DOM前缀',
+        defaultValue: '搜索并打开'
+    },
+    {
+        property: '其余属性',
+        propType: '--',
+        required: false,
+        description: '继承 Antd Modal、AutoComplete API',
+        defaultValue: ''
+    }
+];
 
 const otherDependencies = `import { Button } from 'antd';
 import { SearchModal } from 'dt-react-component';`;
 
-const functionCode = `state={
+const functionCode = `initDataSource = ['gmail.com', '163.com', 'qq.com'];
+    state = {
         visible: false,
-        key: Math.random()
+        dataSource: this.initDataSource,
     }`;
 
 const code = `<div>
@@ -44,58 +74,156 @@ const code = `<div>
                     点击我
                 </Button>
                 <SearchModal
-                    name='notebook'
-                    title='搜索并打开 notebook'
-                    key={this.state.key}
-                    visible={this.state.visible}
-                    onSelect={() => { console.log('onSelect') }}
-                    onChange={() => { console.log('onChange') }}
+                <SearchModal
+                    prefixRender={
+                        <Select defaultValue={1} style={{ width: '100%' }}>
+                            <Option value={1}>任务名称</Option>
+                            <Option value={2}>任务描述</Option>
+                        </Select>
+                    }
+                    dataSource={state.dataSource}
+                    visible={state.visible}
                     onCancel={() => {
-                        this.setState({
-                            visible: false,
-                            key: Math.random() 
-                        })
+                        store.set({ visible: false });
                     }}
+                    onSelect={(value, option) => {
+                        console.log('onSelect, ' + value, option);
+                    }}
+                    onChange={(value) => {
+                        console.log('onChange' + value);
+                        store.set({
+                            dataSource: this.initDataSource.filter((item: string) => item.indexOf(value) !== -1)
+                        });
+                    }}
+            />
                 />
             </div>`;
+
+const searchCode = `<div>
+                <Button
+                    onClick={() => {
+                        this.setState({
+                            visible: true
+                        })
+                    }}
+                >
+                    点击我
+                </Button>
+                <SearchModal
+                    key={state.key}
+                    dataSource={state.dataSource}
+                    closable={false}
+                    mask={false}
+                    visible={state.visible1}
+                    placeholder="选中后将关闭modal"
+                    onSelect={(value, option) => {
+                        console.log('onSelect, ' + value, option);
+                        store.set({ visible1: false });
+                    }}
+                    onChange={(value) => {
+                        console.log('onChange' + value);
+                        store.set({
+                            dataSource: this.initDataSource.filter((item: string) => item.indexOf(value) !== -1)
+                        });
+                    }}
+                    title={null}
+            />
+            </div>`;
 const stories = storiesOf('SearchModal 全局搜索弹框', module);
-stories.add('searchModal', () => {
-    return (
-        <div className='story_wrapper'>
-            <h2>何时使用</h2>
-            <p>路由未匹配上的展示页</p>
-            <h2>示例</h2>
-            <ExampleContainer
-                otherDependencies={otherDependencies}
-                code={code}
-                hasCodeSandBox={true}
-                functionCode={functionCode}
-            >
-                <Button onClick={() => {
-                    store.set({ visible: true })
-                }}>点击我</Button>
-                <State store={store} >
-                    {
-                        (state) => <SearchModal
-                            key={state.key}
-                            visible={state.visible}
-                            onCancel={() => {
-                                store.set({ visible: false, key: Math.random() })
-                            }}
-                            onSelect={() => { console.log('onSelect') }}
-                            onChange={() => { console.log('onChange') }}
-                            title='搜索并打开 notebook'
-                            name='notebook'
-                        />
-                    }
-                </State>
-                <SearchModal visible={false} style={{ display: 'none' }} />
-            </ExampleContainer>
-        </div>
-    )
-}, {
-    info: {
-        text: `
+stories.add(
+    'searchModal',
+    () => {
+        return (
+            <div className="story_wrapper">
+                <h2>何时使用</h2>
+                <p>路由未匹配上的展示页</p>
+                <h2>示例1</h2>
+                <p>带有自定义DOM前缀</p>
+                <ExampleContainer
+                    otherDependencies={otherDependencies}
+                    code={code}
+                    hasCodeSandBox={true}
+                    functionCode={functionCode}
+                >
+                    <Button
+                        onClick={() => {
+                            store.set({ visible: true });
+                        }}
+                    >
+                        点击我
+                    </Button>
+                    <State store={store}>
+                        {(state) => (
+                            <SearchModal
+                                prefixRender={
+                                    <Select defaultValue={1} style={{ width: '100%' }}>
+                                        <Option value={1}>任务名称</Option>
+                                        <Option value={2}>任务描述</Option>
+                                    </Select>
+                                }
+                                dataSource={state.dataSource}
+                                key={state.key}
+                                visible={state.visible}
+                                onCancel={() => {
+                                    store.set({ visible: false, key: Math.random() });
+                                }}
+                                onSelect={(value, option) => {
+                                    console.log('onSelect, ' + value, option);
+                                }}
+                                onChange={(value) => {
+                                    console.log('onChange' + value);
+                                    store.set({
+                                        dataSource: initDataSource.filter((item: string) => item.indexOf(value) !== -1)
+                                    });
+                                }}
+                            />
+                        )}
+                    </State>
+                </ExampleContainer>
+                <h2>示例2</h2>
+                <p>只有搜索框</p>
+                <ExampleContainer
+                    otherDependencies={otherDependencies}
+                    code={searchCode}
+                    hasCodeSandBox={true}
+                    functionCode={functionCode}
+                >
+                    <Button
+                        onClick={() => {
+                            store.set({ visible1: true });
+                        }}
+                    >
+                        点击我
+                    </Button>
+                    <State store={store}>
+                        {(state) => (
+                            <SearchModal
+                                dataSource={state.dataSource}
+                                closable={false}
+                                mask={false}
+                                visible={state.visible1}
+                                placeholder="选中后将关闭modal"
+                                onSelect={(value, option) => {
+                                    console.log('onSelect, ' + value, option);
+                                    store.set({ visible1: false });
+                                }}
+                                onChange={(value) => {
+                                    console.log('onChange' + value);
+                                    store.set({
+                                        dataSource: initDataSource.filter((item: string) => item.indexOf(value) !== -1)
+                                    });
+                                }}
+                                title={null}
+                            />
+                        )}
+                    </State>
+                </ExampleContainer>
+            </div>
+        );
+    },
+    {
+        info: {
+            text: `
         代码示例：
         ~~~js
         import { SearchModal } from 'dt-react-component'
@@ -109,7 +237,8 @@ stories.add('searchModal', () => {
         />
         ~~~
         `,
-        TableComponent: () => PropsTable({ propDefinitions }),
-        propTablesExclude: [Button, State]
+            TableComponent: () => PropsTable({ propDefinitions }),
+            propTablesExclude: [Button, State]
+        }
     }
-})
+);


### PR DESCRIPTION
- 去除原先下拉DOM元素，改成`prefixRender`自定义DOM的方式。
- 更改 `title` 默认值方式，传入 `null` 隐藏 Modal `title`
- 支持传入 antd Modal 的API

示例1：
![image](https://user-images.githubusercontent.com/46592356/129005816-895f6740-6c1d-4ca2-a100-e2af68414aa9.png)

示例2：
![image](https://user-images.githubusercontent.com/46592356/129006143-504503bf-53e3-44c5-8a83-f9d86cb0c298.png)

