### PR TITLE
Fix Icon import bug in GoBack and CopyIcon

### DIFF
--- a/src/components/copyIcon/index.tsx
+++ b/src/components/copyIcon/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Icon, Tooltip, message } from 'antd';
+import { Tooltip, message } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
+
 
 export interface CopyIconProps {
     text: string;
@@ -101,7 +103,7 @@ export default class CopyIcon extends React.Component<any, any> {
             <span onClick={this.copy.bind(this, text)}>{customRender}</span>
         ) : (
             <Tooltip placement="right" title={title || '复制'}>
-                <Icon {...rest} className="c-copyIcon" onClick={this.copy.bind(this, text)} style={style} type="copy" />
+                <CopyOutlined {...rest} className="c-copyIcon" onClick={this.copy.bind(this, text)} style={style} />
             </Tooltip>
         );
     }

--- a/src/components/goBack/goBack.tsx
+++ b/src/components/goBack/goBack.tsx
@@ -41,7 +41,7 @@ export default class GoBack extends React.Component<GoBackProps, any> {
 
         return (
             <LeftCircleOutlined
-                style={iconStyle} 
+                style={iconStyle}
                 onClick={this.go}
             />
         )

--- a/src/components/goBack/goBack.tsx
+++ b/src/components/goBack/goBack.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon } from 'antd/lib'
+import { LeftCircleOutlined } from '@ant-design/icons';
 import { browserHistory, hashHistory } from 'react-router'
 import { GoBackProps } from './index'
 
@@ -40,9 +40,8 @@ export default class GoBack extends React.Component<GoBackProps, any> {
         }
 
         return (
-            <Icon
-                style={iconStyle}
-                type={'left-circle-o'}
+            <LeftCircleOutlined
+                style={iconStyle} 
                 onClick={this.go}
             />
         )


### PR DESCRIPTION
## Introduction
Fix Icon import bug in GoBack and CopyIcon

## Features
- Changed Icon from GoBack to LeftCircleOutlined.
- Changed Icon from original CopyIcon to CopyOutlined.