### PR TITLE
Fix 3.0.x ts define

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     }
   },
   "devDependencies": {
-    "@ant-design/compatible": "^1.1.0",
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
@@ -158,6 +157,7 @@
     "url-loader": "^4.1.0"
   },
   "dependencies": {
+    "@ant-design/compatible": "^1.1.0",
     "@ant-design/icons": "^4.7.0",
     "@handsontable/react": "^2.1.0",
     "antd": "4.18.9",

--- a/src/components/blockHeader/index.tsx
+++ b/src/components/blockHeader/index.tsx
@@ -22,12 +22,10 @@ export interface BlockHeaderProps {
     showBackground?: boolean;
     // 是否默认展开内容, 默认 true
     defaultExpand?: boolean;
-    // 展开/收起的内容
-    children?: React.ReactNode;
     // 展开/收起时的回调
     onChange?: (expand: boolean) => void;
 }
-export default function BlockHeader (props: BlockHeaderProps) {
+const BlockHeader: React.FC<BlockHeaderProps> = function (props) {
     const prefixCls = 'dtc-block-header';
     const {
         title,
@@ -84,3 +82,5 @@ export default function BlockHeader (props: BlockHeaderProps) {
         </div>
     )
 }
+
+export default BlockHeader

--- a/src/components/circle/index.tsx
+++ b/src/components/circle/index.tsx
@@ -1,24 +1,25 @@
 import React from 'react'
 import classNames from 'classnames'
 
-export const tuple = <T extends string[]>(...args: T) => args;
-const CicleTypes = tuple('running', 'finished', 'stopped', 'frozen', 'fail',
-    'submitting', 'restarting', 'waitSubmit');
-export type CicleType = typeof CicleTypes[number]
+export type CircleType = 'running'| 'finished'| 'stopped'| 'frozen'| 'fail'| 'submitting'| 'restarting'| 'waitSubmit'
 
 export interface CircleProps {
-    type?: CicleType;
+    type?: CircleType;
     className?: string;
     style?: React.CSSProperties;
     onClick?: () => void;
-    children?: React.ReactNode;
 }
-export default function Circle (props: CircleProps) {
+
+const Circle: React.FC<CircleProps> = function Circle (props) {
     const { className, type } = props;
     const prefixCls = 'dtc-circle';
-    const classes = classNames(`${prefixCls}-default`, className, {
-        [`${prefixCls}-${type}`]: type
-    })
+
+    const classes = classNames(
+        `${prefixCls}-default`,
+        className, 
+        {[`${prefixCls}-${type}`]: type}
+    )
+
     const { ...other } = props;
     return (
         <div
@@ -29,3 +30,5 @@ export default function Circle (props: CircleProps) {
         </div>
     )
 }
+
+export default Circle

--- a/src/components/circle/index.tsx
+++ b/src/components/circle/index.tsx
@@ -11,7 +11,7 @@ export interface CircleProps {
 }
 
 const Circle: React.FC<CircleProps> = function Circle (props) {
-    const { className, type } = props;
+    const { className, type, ...other  } = props;
     const prefixCls = 'dtc-circle';
 
     const classes = classNames(
@@ -20,7 +20,6 @@ const Circle: React.FC<CircleProps> = function Circle (props) {
         {[`${prefixCls}-${type}`]: type}
     )
 
-    const { ...other } = props;
     return (
         <div
             {...other}

--- a/src/components/contextMenu/index.tsx
+++ b/src/components/contextMenu/index.tsx
@@ -10,7 +10,6 @@ export interface ContextMenuProps {
 export interface ContextMenuItemProps {
     key?: string;
     onClick?: () => void;
-    children?: React.ReactNode;
     value?: string;
     [propName: string]: any;
 }

--- a/src/components/contextMenuCombiner/index.tsx
+++ b/src/components/contextMenuCombiner/index.tsx
@@ -9,7 +9,6 @@ export interface ContextMenuCombinerProps {
     ctxMenuWrapperClsName: string;
     operations?: Operation[];
     id: any;
-    children?: React.ReactNode;
 }
 
 

--- a/src/components/cookies/index.tsx
+++ b/src/components/cookies/index.tsx
@@ -9,7 +9,6 @@ export interface CookiesProps {
     watchFields?: string[];
     onChanged?: (old: string, newCookie: string) => void;
     onFieldsChanged?: (fields: Fields[]) => void;
-    children?: React.ReactNode;
 }
 /**
  * Cookies 组件

--- a/src/components/cookies/index.tsx
+++ b/src/components/cookies/index.tsx
@@ -1,14 +1,14 @@
 
 import React from 'react'
 
-interface Filds {
+export interface Fields {
     key?: string;
     value? : string;
 }
 export interface CookiesProps {
     watchFields?: string[];
     onChanged?: (old: string, newCookie: string) => void;
-    onFieldsChanged?: (fields: Filds[]) => void;
+    onFieldsChanged?: (fields: Fields[]) => void;
     children?: React.ReactNode;
 }
 /**
@@ -42,13 +42,12 @@ class Cookies extends React.Component<CookiesProps, any> {
     onFieldsChange = (old: string, newCookies: string) => {
         const { watchFields, onFieldsChanged } = this.props;
         if (watchFields) {
-            const changedFields: Filds[] = [];
+            const changedFields: Fields[] = [];
             for (let i = 0; i < watchFields.length; i++) {
                 const key = watchFields[i];
                 const originValue = this.getCookieValue(old, key);
                 const newValue = this.getCookieValue(newCookies, key);
                 if (originValue !== null && originValue !== newValue) {
-                    console.log('fieldChanged:', key, originValue, newValue);
                     changedFields.push({ key, value: newValue });
                 }
             }
@@ -64,7 +63,7 @@ class Cookies extends React.Component<CookiesProps, any> {
             const arr = cookies.match(
                 new RegExp('(^| )' + name + '=([^;]*)(;|$)')
             );
-            if (arr != null) return unescape(decodeURI(arr[2]));
+            if (arr != null) return decodeURI(arr[2]);
         }
         return null;
     }

--- a/src/components/dragDrawer/index.tsx
+++ b/src/components/dragDrawer/index.tsx
@@ -5,13 +5,11 @@ interface DragDrawerProps extends DrawerProps {
     draggable?: boolean;
     minWidth?: number;
     maxWidth?: number;
-    // 抽屉的内容
-    children?: React.ReactNode;
     onDrag?: Function;
 }
 
 const prefixCls = 'dtc-drag-drawer';
-export default function DragDrawer (props: DragDrawerProps) {
+const DragDrawer: React.FC<DragDrawerProps> = function (props) {
     const {
         visible,
         draggable = true,
@@ -63,3 +61,5 @@ export default function DragDrawer (props: DragDrawerProps) {
         </Drawer>
     )
 }
+
+export default DragDrawer

--- a/src/components/errorBoundary/index.tsx
+++ b/src/components/errorBoundary/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import LoadError from '../loadError';
 
 interface ErrorBoundaryProps {
-    children?: React.ReactNode;
 }
 
 interface ErrorBoundaryStates {

--- a/src/components/keyEventListener/index.tsx
+++ b/src/components/keyEventListener/index.tsx
@@ -4,7 +4,6 @@ import KeyCombiner from './listener'
 export interface KeyEventListenerProps {
     onKeyDown?: (e) => void;
     onKeyUp?: (e) => void;
-    children?: React.ReactNode;
 }
 
 export default class KeyEventListener extends React.Component<KeyEventListenerProps, any> {

--- a/src/components/multiSearchInput/index.tsx
+++ b/src/components/multiSearchInput/index.tsx
@@ -29,7 +29,7 @@ const searchTypeList: any = [
     }
 ];
 
-type SearchType = 'fuzzy' | 'precise' | 'front' | 'tail';
+export type SearchType = 'fuzzy' | 'precise' | 'front' | 'tail';
 
 export interface MultiSearchInputProps {
     placeholder?: string;

--- a/src/components/resize/index.tsx
+++ b/src/components/resize/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 export interface ResizeProps {
     onResize?: Function;
-    children?: React.ReactNode;
 }
 export default class Resize extends React.Component<ResizeProps, any> {
     componentDidMount () {

--- a/src/components/scrollText/index.tsx
+++ b/src/components/scrollText/index.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 export interface ScrollTextProps {
     value?: string;
     style?: React.CSSProperties;
-    children?: React.ReactNode;
 }
 
 export default function scrollText (props: ScrollTextProps) {

--- a/src/components/switchWindow/index.tsx
+++ b/src/components/switchWindow/index.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 export interface SwitchWindowProps {
     onSwitch?: (evt) => void;
     style?: React.CSSProperties;
-    children?: React.ReactNode;
 }
 /**
  * 窗口切换事件监听，

--- a/src/components/toolModal/index.tsx
+++ b/src/components/toolModal/index.tsx
@@ -8,7 +8,6 @@ export interface ToolModalProps {
     visible: boolean;
     toolbox?: React.ReactNode | string;
     fullscreen?: boolean | undefined;
-    children?: React.ReactNode;
     [propName: string]: any;
 
 }


### PR DESCRIPTION
## ChangeSet
1. Cicle 组件：修正 Circle 组件的 CicleType 类型定义；并修正 CicleType 类型名称为 **_CircleType_**
2. MultiSearchInput 组件：具名导出 SearchType 类型定义
3. Cookies 组件：修正类型名称 Filds 为 Fields；并具名导出 Fields 类型定义；移除 getCookieValue 中的 unescape 函数，因为这是无效代码，具体说明看[这里](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/unescape)
5. 将 @ant-design/compatible 依赖从 packages.json 的 devDependencies 移到 dependencies，因为 studio 仓库在更新dt-react-component 时会移除 devDependencies 中所有的依赖
6. 移除下列组件中类型接口中的 children 成员，因为这是无效代码

- BlockHeaderProps
- CircleProps
- ContextMenuItemProps
- ContextMenuCombinerProps
- CookiesProps
- DragDrawerProps
- ErrorBoundaryProps
- KeyEventListenerProps
- ResizeProps
- ScrollTextProps
- SwitchWindowProps
- ToolModalProps

## BreakPoint
Circle 组件中导出的 CicleType 类型名称变更为 CircleType
