### PR TITLE
feat: enable tree shaking optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "2.2.0",
   "description": "react-component",
   "repository": "https://github.com/DTStack/dt-react-component",
+  "sideEffects": [
+    "lib/*",
+    "esm/**/style/*",
+    "lib/**/style/*",
+    "*.scss"
+  ],
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/src/components/goBack/goBack.tsx
+++ b/src/components/goBack/goBack.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon } from 'antd/lib'
+import { Icon } from 'antd'
 import { browserHistory, hashHistory } from 'react-router'
 import { GoBackProps } from './index'
 


### PR DESCRIPTION
1. remove import from `antd/lib` which cause total import of `antd/lib`
2. add `sideEffects` to specify side effects when using webpack to bundle 