### PR TITLE
feat: mxgraph css

### DIFF
--- a/src/components/mxGraph/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/mxGraph/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`The mxGraph Container test Match Snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="graph-editor"
+    class="dtc-graph-editor"
   >
     <div
-      class="ant-spin-nested-loading task-graph"
+      class="ant-spin-nested-loading dtc-task-graph"
     >
       <div
         class="ant-spin-container"
@@ -29,10 +29,10 @@ exports[`The mxGraph Container test Match Snapshot 1`] = `
       </div>
     </div>
     <div
-      class="graph-bottom"
+      class="dtc-graph-bottom"
     />
     <div
-      class="graph-toolbar"
+      class="dtc-graph-toolbar"
     />
   </div>
 </DocumentFragment>
@@ -41,10 +41,10 @@ exports[`The mxGraph Container test Match Snapshot 1`] = `
 exports[`The mxGraph Container test Match Snapshot with data and toolbar 1`] = `
 <DocumentFragment>
   <div
-    class="graph-editor"
+    class="dtc-graph-editor"
   >
     <div
-      class="ant-spin-nested-loading task-graph"
+      class="ant-spin-nested-loading dtc-task-graph"
     >
       <div
         class="ant-spin-container"
@@ -162,10 +162,10 @@ exports[`The mxGraph Container test Match Snapshot with data and toolbar 1`] = `
       </div>
     </div>
     <div
-      class="graph-bottom"
+      class="dtc-graph-bottom"
     />
     <div
-      class="graph-toolbar"
+      class="dtc-graph-toolbar"
     >
       <button>
         +
@@ -181,10 +181,10 @@ exports[`The mxGraph Container test Match Snapshot with data and toolbar 1`] = `
 exports[`The mxGraph Container test Match Snapshot with data and widgets 1`] = `
 <DocumentFragment>
   <div
-    class="graph-editor"
+    class="dtc-graph-editor"
   >
     <div
-      class="ant-spin-nested-loading task-graph"
+      class="ant-spin-nested-loading dtc-task-graph"
     >
       <div
         class="ant-spin-container"
@@ -302,7 +302,7 @@ exports[`The mxGraph Container test Match Snapshot with data and widgets 1`] = `
       </div>
     </div>
     <div
-      class="graph-widgets"
+      class="dtc-graph-widgets"
     >
       <div
         style="height: 20px; background: rgb(221, 221, 221);"
@@ -321,10 +321,10 @@ exports[`The mxGraph Container test Match Snapshot with data and widgets 1`] = `
       </ul>
     </div>
     <div
-      class="graph-bottom"
+      class="dtc-graph-bottom"
     />
     <div
-      class="graph-toolbar"
+      class="dtc-graph-toolbar"
     />
   </div>
 </DocumentFragment>
@@ -333,11 +333,11 @@ exports[`The mxGraph Container test Match Snapshot with data and widgets 1`] = `
 exports[`The mxGraph Container test Match Snapshot with style and bottom status bar 1`] = `
 <DocumentFragment>
   <div
-    class="graph-editor"
+    class="dtc-graph-editor"
     style="background: rgb(221, 221, 221);"
   >
     <div
-      class="ant-spin-nested-loading task-graph"
+      class="ant-spin-nested-loading dtc-task-graph"
     >
       <div
         class="ant-spin-container"
@@ -455,14 +455,14 @@ exports[`The mxGraph Container test Match Snapshot with style and bottom status 
       </div>
     </div>
     <div
-      class="graph-bottom"
+      class="dtc-graph-bottom"
     >
       <div>
         This is legend
       </div>
     </div>
     <div
-      class="graph-toolbar"
+      class="dtc-graph-toolbar"
     />
   </div>
 </DocumentFragment>

--- a/src/components/mxGraph/__tests__/index.test.tsx
+++ b/src/components/mxGraph/__tests__/index.test.tsx
@@ -63,7 +63,7 @@ describe('The mxGraph Container test', () => {
         );
 
         const widgetsParentNode = container.querySelector<HTMLDivElement>(
-            '.graph-widgets'
+            '.dtc-graph-widgets'
         );
         // NOTHING happened
         fireEvent.contextMenu(widgetsParentNode);

--- a/src/components/mxGraph/factory.tsx
+++ b/src/components/mxGraph/factory.tsx
@@ -337,6 +337,26 @@ class MxFactory {
     }
 
     /**
+     * 渲染 tooltips 的 HTML 样式
+     * @description Returns the string or DOM node to be used as the tooltip for the given cell. This implementation uses the cells getTooltip function if it exists, or else it returns convertValueToString for the cell.
+     */
+    renderTooltips (handler: (cell: mxCell) => string | undefined) {
+        if (this.mxGraph) {
+            // 默认 tooltips
+            this.mxGraph.getTooltipForCell = (cell) => {
+                if (cell && cell.vertex) {
+                    const result = handler(cell);
+                    if (result === undefined) {
+                        return this.mxGraph.getLabel(cell) as string;
+                    }
+                    return result;
+                }
+                return '';
+            };
+        }
+    }
+
+    /**
      * 初始化 graph 相关配置
      */
     public initContainerScroll = () => {

--- a/src/components/mxGraph/index.tsx
+++ b/src/components/mxGraph/index.tsx
@@ -914,12 +914,12 @@ function MxGraphContainer<T extends IMxGraphData>(
     }, []);
 
     return (
-        <div className="graph-editor" style={style}>
+        <div className="dtc-graph-editor" style={style}>
             <Spin
                 tip="Loading..."
                 size="large"
                 spinning={loading}
-                wrapperClassName="task-graph"
+                wrapperClassName="dtc-task-graph"
             >
                 <div
                     style={{
@@ -934,14 +934,14 @@ function MxGraphContainer<T extends IMxGraphData>(
             </Spin>
             {onRenderWidgets && (
                 <div
-                    className="graph-widgets"
+                    className="dtc-graph-widgets"
                     onContextMenu={(e) => e.preventDefault()}
                 >
                     {onRenderWidgets?.()}
                 </div>
             )}
-            <div className="graph-bottom">{children?.(current)}</div>
-            <div className="graph-toolbar" style={config?.toolbarStyle}>
+            <div className="dtc-graph-bottom">{children?.(current)}</div>
+            <div className="dtc-graph-toolbar" style={config?.toolbarStyle}>
                 {onRenderActions?.(graph.current, Mx.mxInstance)}
             </div>
         </div>

--- a/src/components/mxGraph/index.tsx
+++ b/src/components/mxGraph/index.tsx
@@ -190,6 +190,10 @@ export interface IContainerProps<T> {
      */
     onRenderCell?: (cell: mxCell, graph: mxGraph) => string;
     /**
+     * 渲染 cell 的 tooltips，返回 string 类型或 undefined
+     */
+     onRenderTooltips?: (cell: mxCell, graph: mxGraph) => string;
+    /**
      * 获取 vertex 的 style，由于存在默认样式，所以通常用于设置特殊状态的 vertex
      */
     onDrawVertex?: (data: T) => string;
@@ -268,6 +272,7 @@ function MxGraphContainer<T extends IMxGraphData>(
         direction,
         children,
         onRenderCell,
+        onRenderTooltips,
         onDrawVertex,
         onDrawEdge,
         onClick,
@@ -393,6 +398,11 @@ function MxGraphContainer<T extends IMxGraphData>(
         // 转换value显示的内容
         Mx.renderVertex((cell) => {
             return onRenderCell?.(cell, graph.current!) || '';
+        });
+
+        // 自定义 tooltips
+        Mx.renderTooltips((cell) => {
+            return onRenderTooltips?.(cell, graph.current!);
         });
 
         Mx.layoutEventHandler = () => {

--- a/src/components/mxGraph/style.scss
+++ b/src/components/mxGraph/style.scss
@@ -1,88 +1,9 @@
-.mxTooltip {
-    position: absolute;
-    display: block;
-    box-sizing: border-box;
-    margin: 0;
-    padding: 10px;
-    color: #ffffff;
-    font-size: 11px;
-    font-family: 'Arial', sans-serif;
-    font-variant: tabular-nums;
-    line-height: 1.5;
-    word-wrap: break-word;
-    list-style: none;
-    background: #ffffff;
-    border: none;
-    border-radius: 0;
-    box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.08);
-    cursor: default;
-    font-feature-settings: 'tnum';
-
-    .vertex-title {
-        color: inherit;
-    }
-
-    .vertex {
-        color: #ffffff;
-    }
-}
-
-div.mxPopupMenu {
-    position: absolute;
-    background: #fff;
-    border: 0;
-    border-radius: 0;
-    box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.08);
-
-    table.mxPopupMenu {
-        margin: 4px 0;
-        border-collapse: collapse;
-
-        tr.mxPopupMenuItem {
-            color: #000;
-            cursor: default;
-        }
-
-        td.mxPopupMenuItem {
-            padding: 6px 60px 6px 30px;
-            color: #000;
-            font-size: 12px;
-            font-family: 'PingFangSC-Regular', sans-serif;
-            letter-spacing: 0;
-            border: none;
-
-            &.mxDisabled {
-                color: #ddd;
-                cursor: not-allowed;
-            }
-        }
-
-        td.mxPopupMenuIcon {
-            padding: 0;
-            background-color: #fff;
-        }
-
-        tr.mxPopupMenuItemHover {
-            background-color: #e6f7ff;
-            cursor: pointer;
-
-            .mxPopupMenuItem {
-                color: #2491f7;
-            }
-        }
-
-        hr {
-            border-top: solid 1px #ccc;
-        }
-    }
-}
-
-.graph-editor {
+.dtc-graph-editor {
     position: relative;
     height: 100%;
     background-color: #fff;
 
-    .task-graph {
+    .dtc-task-graph {
         height: 100%;
     }
 
@@ -90,7 +11,7 @@ div.mxPopupMenu {
         height: 100%;
     }
 
-    .graph-widgets {
+    .dtc-graph-widgets {
         background: #fff;
         border: 1px solid #ddd;
         max-height: 517px;
@@ -103,7 +24,7 @@ div.mxPopupMenu {
         z-index: 3;
     }
 
-    .graph-bottom {
+    .dtc-graph-bottom {
         position: absolute;
         bottom: 0;
         z-index: 999;
@@ -111,7 +32,7 @@ div.mxPopupMenu {
         width: 100%;
     }
 
-    .graph-toolbar {
+    .dtc-graph-toolbar {
         position: absolute;
         top: 20px;
         right: 14px;
@@ -119,25 +40,5 @@ div.mxPopupMenu {
         height: 18px;
         text-align: center;
         border-radius: 0;
-    }
-
-    .graph-info {
-        width: 100%;
-        height: 35px;
-        padding: 0 20px;
-        color: #fff;
-        font-size: 12px;
-        font-family: 'PingFangSC-Regular', sans-serif;
-        line-height: 35px;
-        letter-spacing: 0;
-        background-color: #fff;
-        border-bottom: 1px solid #ddd;
-    }
-
-    .graph-status {
-        @extend .graph-info;
-
-        background-color: #fff;
-        border-bottom: 0;
     }
 }

--- a/src/stories/mxGraph.stories.tsx
+++ b/src/stories/mxGraph.stories.tsx
@@ -14,14 +14,19 @@ const otherDependencies =
 stories.add('mxGraph 基础使用', () => {
     return (
         <div className="story_wrapper">
+            <h2>Tips</h2>
+            <p>mxTooltip、mxPopupMenu、mxPopupMenuItem 等样式请自行实现，可参考：
+                <a href="https://github.com/DTStack/dt-react-component/blob/master/src/stories/style/mxGraph.scss" target="blank">mxGraph.scss</a>
+            </p>
+
             <h2>示例</h2>
-            <p>mxGraph 的基础使用，展示图数据</p>
+            <p>mxGraph 的基础使用，展示图数据，开启了 tooltips</p>
             <ExampleContainer
                 otherDependencies={otherDependencies}
                 code={`<MxGraphContainer
                 style={{ height: 400 }}
                 config={{
-                    tooltips: false,
+                    tooltips: true,
                     highlight: true
                 }}
                 graphData={[
@@ -79,17 +84,23 @@ stories.add('mxGraph 基础使用', () => {
                         </Tooltip>
                     </div>
                 )}
-                onRenderCell={(cell) => {
+                onRenderCell={(cell, graph) => {
                     if (cell.vertex && cell.value) {
                         const task = cell.value;
                         if (task) {
-                            return ReactDOMServer.renderToString(
+                            const cellDom = ReactDOMServer.renderToString(
                                 <div>
-                                    <span>{task.taskName}</span>
+                                    <span>{task?.taskName}</span>
                                     <br />
-                                    <span>{task.taskId}</span>
+                                    <span>{task?.taskId}</span>
                                 </div>
                             );
+                            // 自定义 tooltips
+                            graph.getTooltipForCell = (cell) => {
+                                return cellDom;
+                            };
+
+                            return cellDom;
                         }
                     }
                     return '';
@@ -100,7 +111,7 @@ stories.add('mxGraph 基础使用', () => {
                 <MxGraphContainer
                     style={{ height: 400 }}
                     config={{
-                        tooltips: false,
+                        tooltips: true,
                         highlight: true
                     }}
                     graphData={[
@@ -158,17 +169,23 @@ stories.add('mxGraph 基础使用', () => {
                             </Tooltip>
                         </div>
                     )}
-                    onRenderCell={(cell) => {
+                    onRenderCell={(cell, graph) => {
                         if (cell.vertex && cell.value) {
                             const task = cell.value;
                             if (task) {
-                                return ReactDOMServer.renderToString(
+                                const cellDom = ReactDOMServer.renderToString(
                                     <div>
-                                        <span>{task.taskName}</span>
+                                        <span>{task?.taskName}</span>
                                         <br />
-                                        <span>{task.taskId}</span>
+                                        <span>{task?.taskId}</span>
                                     </div>
                                 );
+                                // 自定义 tooltips
+                                graph.getTooltipForCell = (cell) => {
+                                    return cellDom;
+                                };
+
+                                return cellDom;
                             }
                         }
                         return '';

--- a/src/stories/mxGraph.stories.tsx
+++ b/src/stories/mxGraph.stories.tsx
@@ -84,24 +84,24 @@ stories.add('mxGraph 基础使用', () => {
                         </Tooltip>
                     </div>
                 )}
-                onRenderCell={(cell, graph) => {
+                onRenderCell={(cell) => {
                     if (cell.vertex && cell.value) {
                         const task = cell.value;
                         if (task) {
-                            const cellDom = ReactDOMServer.renderToString(
+                            return ReactDOMServer.renderToString(
                                 <div>
-                                    <span>{task?.taskName}</span>
+                                    <span>{task.taskName}</span>
                                     <br />
-                                    <span>{task?.taskId}</span>
+                                    <span>{task.taskId}</span>
                                 </div>
                             );
-                            // 自定义 tooltips
-                            graph.getTooltipForCell = (cell) => {
-                                return cellDom;
-                            };
-
-                            return cellDom;
                         }
+                    }
+                    return '';
+                }}
+                onRenderTooltips={(cell) => {
+                    if (cell.vertex && cell.value) {
+                        return cell.value.taskName;
                     }
                     return '';
                 }}
@@ -169,24 +169,24 @@ stories.add('mxGraph 基础使用', () => {
                             </Tooltip>
                         </div>
                     )}
-                    onRenderCell={(cell, graph) => {
+                    onRenderCell={(cell) => {
                         if (cell.vertex && cell.value) {
                             const task = cell.value;
                             if (task) {
-                                const cellDom = ReactDOMServer.renderToString(
+                                return ReactDOMServer.renderToString(
                                     <div>
-                                        <span>{task?.taskName}</span>
+                                        <span>{task.taskName}</span>
                                         <br />
-                                        <span>{task?.taskId}</span>
+                                        <span>{task.taskId}</span>
                                     </div>
                                 );
-                                // 自定义 tooltips
-                                graph.getTooltipForCell = (cell) => {
-                                    return cellDom;
-                                };
-
-                                return cellDom;
                             }
+                        }
+                        return '';
+                    }}
+                    onRenderTooltips={(cell) => {
+                        if (cell.vertex && cell.value) {
+                            return cell.value.taskName;
                         }
                         return '';
                     }}

--- a/src/stories/style/index.scss
+++ b/src/stories/style/index.scss
@@ -5,3 +5,4 @@
 @import './cookies.scss';
 @import './textMark.scss';
 @import './easySelect.scss';
+@import './mxGraph.scss';

--- a/src/stories/style/mxGraph.scss
+++ b/src/stories/style/mxGraph.scss
@@ -1,0 +1,78 @@
+.mxTooltip {
+    position: absolute;
+    display: block;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 10px;
+    color: #333;
+    font-size: 11px;
+    font-family: 'Arial', sans-serif;
+    font-variant: tabular-nums;
+    line-height: 1.5;
+    word-wrap: break-word;
+    list-style: none;
+    background: #ffffff;
+    border: none;
+    border-radius: 0;
+    box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.08);
+    cursor: default;
+    font-feature-settings: 'tnum';
+
+    .vertex-title {
+        color: inherit;
+    }
+
+    .vertex {
+        color: #ffffff;
+    }
+}
+
+div.mxPopupMenu {
+    position: absolute;
+    background: #fff;
+    border: 0;
+    border-radius: 0;
+    box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.08);
+
+    table.mxPopupMenu {
+        margin: 4px 0;
+        border-collapse: collapse;
+
+        tr.mxPopupMenuItem {
+            color: #000;
+            cursor: default;
+        }
+
+        td.mxPopupMenuItem {
+            padding: 6px 60px 6px 30px;
+            color: #000;
+            font-size: 12px;
+            font-family: 'PingFangSC-Regular', sans-serif;
+            letter-spacing: 0;
+            border: none;
+
+            &.mxDisabled {
+                color: #ddd;
+                cursor: not-allowed;
+            }
+        }
+
+        td.mxPopupMenuIcon {
+            padding: 0;
+            background-color: #fff;
+        }
+
+        tr.mxPopupMenuItemHover {
+            background-color: #e6f7ff;
+            cursor: pointer;
+
+            .mxPopupMenuItem {
+                color: #2491f7;
+            }
+        }
+
+        hr {
+            border-top: solid 1px #ccc;
+        }
+    }
+}


### PR DESCRIPTION
#198 MxGraph 组件样式覆盖问题

### 简介

mxgraph 样式

### 说明

1、子产品源码引入 RC 时，mxgraph 部分样式文件会影响子产品写的样式，将这部分示例 css 迁移到示例文件内，同时部分 className 添加 dtc- 标识。  
2、添加 tooltips 示例。  
3、添加 onRenderTooltips 方法，不调用则 tooltips 内容和 cell 内容一致。