### PR TITLE
fix: prevent menu event propagation to treeNode

### DIFF
--- a/src/components/contextMenu/index.tsx
+++ b/src/components/contextMenu/index.tsx
@@ -46,7 +46,10 @@ export default function ContextMenu({
     const menu = (
         <Menu
             className="dt-contextMenu-menu"
-            onClick={(item) => data.find((i) => i.key === item.key)?.cb?.()}
+            onClick={(item) => {
+                item.domEvent.stopPropagation();
+                data.find((i) => i.key === item.key)?.cb?.();
+            }}
         >
             {data.map((item) =>
                 item.confirm ? (


### PR DESCRIPTION
### 简介
- 修复事件冒泡导致 contextMenu 会触发父级的 onClick 事件



### Related Issues

Closed #253 