### PR TITLE
fix: get init fullscreen state when mount

### DIFF
--- a/src/components/fullscreen/index.tsx
+++ b/src/components/fullscreen/index.tsx
@@ -55,6 +55,18 @@ export default class Fullscreen extends React.Component<FullscreenProps, Fullscr
                 this.dispatchResizeEvent
             );
         };
+        const isFullScreen = !!(
+            document.fullscreen ||
+            document.mozFullScreen ||
+            document.webkitIsFullScreen ||
+            document.webkitFullScreen ||
+            document.msFullScreen
+        );
+        if (isFullScreen) {
+            this.setState({
+                isFullScreen: true,
+            });
+        }
         if (domEle.requestFullscreen) {
             domEle.onfullscreenchange = callBack;
         } else if (domEle.msRequestFullscreen) {


### PR DESCRIPTION
全屏组件 在初始化时需要判断当前是否已经处于全屏状态