### PR TITLE
fix: correct StatusTagProps defination

### DIFF
--- a/src/components/statusTag/index.tsx
+++ b/src/components/statusTag/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 export type StatusTagType = 'warning' | 'error' | 'success' | 'run' | 'stopped';
 
-export interface StatusTagProps {
+export interface StatusTagProps extends React.HTMLAttributes<HTMLDivElement>{
     type?: StatusTagType;
     className?: string;
     showBorder?: boolean;


### PR DESCRIPTION
#259 
StatusTagProps 类型定义应当继承自 React.HTMLAttributes<HTMLDivElement>， 因为 status 组件的外层 div 接收了 other props  [看这里](https://github.com/DTStack/dt-react-component/blob/master/src/components/statusTag/index.tsx#L28) 