### PR TITLE
Fix ellipsis text

### DIFF
--- a/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
+++ b/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
@@ -48,6 +48,32 @@ describe('test ellipsis text if not set max width', () => {
     });
 });
 
+describe('auto calculate ellipsis text if the parent element does not exist', () => {
+    beforeEach(() => {
+        Object.defineProperty(window, 'getComputedStyle', {
+            value: jest.fn(() => ({
+                paddingLeft: '0px',
+                paddingRight: '0px',
+            })),
+        });
+
+        wrapper = render(<EllipsisText {...defaultProps} />);
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test('render correct value in ellipsis', () => {
+        const { getByText } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('120px');
+    });
+});
+
 describe('test ellipsis text if set max width', () => {
     beforeEach(() => {
         Object.defineProperty(window, 'getComputedStyle', {

--- a/src/components/ellipsisText/index.tsx
+++ b/src/components/ellipsisText/index.tsx
@@ -24,6 +24,8 @@ export interface NewHTMLElement extends HTMLElement {
     currentStyle?: CSSStyleDeclaration;
 }
 
+const DEFAULT_MAX_WIDTH = 120;
+
 export default class EllipsisText extends PureComponent<EllipsisTextProps, State> {
     ellipsisRef: HTMLElement | null = null;
     state = {
@@ -58,7 +60,7 @@ export default class EllipsisText extends PureComponent<EllipsisTextProps, State
     // The nearest block parent element
     getMaxWidth = (ele: HTMLElement) => {
         // The default maximum width is 120px when the element does not exist
-        if (!ele) return 120;
+        if (!ele) return DEFAULT_MAX_WIDTH;
         const { scrollWidth, offsetWidth, parentElement } = ele;
         // If inline element, find the parent element
         if (scrollWidth === 0) {

--- a/src/components/ellipsisText/index.tsx
+++ b/src/components/ellipsisText/index.tsx
@@ -57,7 +57,8 @@ export default class EllipsisText extends PureComponent<EllipsisTextProps, State
 
     // The nearest block parent element
     getMaxWidth = (ele: HTMLElement) => {
-        if (!ele) return;
+        // The default maximum width is 120px when the element does not exist
+        if (!ele) return 120;
         const { scrollWidth, offsetWidth, parentElement } = ele;
         // If inline element, find the parent element
         if (scrollWidth === 0) {
@@ -78,6 +79,8 @@ export default class EllipsisText extends PureComponent<EllipsisTextProps, State
 
     onResize = () => {
         const { maxWidth } = this.props;
+        // if props has maxWidth don't have to calculate the text length
+        if (maxWidth) return;
         const ellipsisNode = this.ellipsisRef;
         const rangeWidth = this.getRangeWidth(ellipsisNode);
         const ellipsisWidth = this.getMaxWidth(ellipsisNode.parentElement);

--- a/src/stories/ellipsisText.stories.tsx
+++ b/src/stories/ellipsisText.stories.tsx
@@ -59,14 +59,15 @@ stories.add(
         <div className="story_wrapper">
             <h2>何时使用</h2>
             <p>
-                对长文本内容显示做一定限制，根据最近块级父元素自动计算最大宽度，也可以手动传最大宽度，hover
+                用于长文本省略，根据最近块级父元素自动计算文本最大宽度，也可以手动传最大宽度，当传入maxWidth时不会去动态计算文本宽度，hover
                 显示完整内容。
             </p>
             <ul>
                 <li>自动计算宽度仅限于最近块级父元素下都为行内元素</li>
                 <li>如果最近块级元素为行内块级元素，必须设置宽度</li>
                 <li>使用antd table当表头fixed：true时，请传maxWidth</li>
-                <li>使用多个EllipsisText最好传maxWidth</li>
+                <li>某个元素下使用多个EllipsisText最好传maxWidth</li>
+                <li>大批量数据使用时最好传maxWidth，防止出现性能问题</li>
             </ul>
             <h2>示例</h2>
             <span>场景一：</span>
@@ -96,7 +97,7 @@ stories.add(
                 value={'我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'}
                 maxWidth={200}
             />
-            
+
             <div>
                 <span>场景二（请更改窗口大小）：</span>
                 <EllipsisText


### PR DESCRIPTION
Modify:
1、优化`EllipsisText`组件性能问题，当传入`maxWidth`时不去计算文本宽度 

2、当父元素不存在时返回默认最大宽度120px

3、补充单测和stories文档说明

- #257 
