### PR TITLE
【WIP】 feat: enhanced ellipsisTest

### DIFF
--- a/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
+++ b/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
@@ -89,6 +89,9 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
 
 describe('test ellipsis text if set max width', () => {
     beforeEach(() => {
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValue({
+            width: 600,
+        });
         Object.defineProperty(window, 'getComputedStyle', {
             value: jest.fn(() => ({
                 paddingLeft: '0px',
@@ -140,7 +143,7 @@ describe('test ellipsis text if set max width', () => {
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('1000px');
+        expect(element.style.maxWidth).toBe('1000');
         expect(element.style.cursor).toBe('default');
 
         jest.useFakeTimers();
@@ -148,77 +151,5 @@ describe('test ellipsis text if set max width', () => {
         jest.runAllTimers();
 
         expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeInTheDocument();
-    });
-
-    test('The maximum is a percent，render correct value in ellipsis', () => {
-        waitFor(() => {
-            wrapper = render(
-                <div>
-                    <EllipsisText {...defaultProps} maxWidth="80%" />
-                </div>
-            );
-        });
-        const { getByText, baseElement, getAllByText } = wrapper;
-        const { value } = defaultProps;
-        element = getByText(value);
-
-        expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('80%');
-        expect(element.style.cursor).toBe('pointer');
-
-        jest.useFakeTimers();
-        fireEvent.mouseOver(element);
-        jest.runAllTimers();
-
-        expect(baseElement.querySelector('.ant-tooltip-open')).toBeInTheDocument();
-        expect(getAllByText(value).length).toBe(2);
-    });
-
-    test('The maximum is a relative value，render correct value in ellipsis', () => {
-        waitFor(() => {
-            wrapper = render(
-                <div>
-                    <EllipsisText {...defaultProps} maxWidth="calc(100% - 10px)" />
-                </div>
-            );
-        });
-        const { getByText, baseElement, getAllByText } = wrapper;
-        const { value } = defaultProps;
-        element = getByText(value);
-
-        expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('calc(100% - 10px)');
-        expect(element.style.cursor).toBe('pointer');
-
-        jest.useFakeTimers();
-        fireEvent.mouseOver(element);
-        jest.runAllTimers();
-
-        expect(baseElement.querySelector('.ant-tooltip-open')).toBeInTheDocument();
-        expect(getAllByText(value).length).toBe(2);
-    });
-
-    test('The maximum is a relative value view，render correct value in ellipsis', () => {
-        waitFor(() => {
-            wrapper = render(
-                <div>
-                    <EllipsisText {...defaultProps} maxWidth="calc(100vh - 10px)" />
-                </div>
-            );
-        });
-        const { getByText, baseElement, getAllByText } = wrapper;
-        const { value } = defaultProps;
-        element = getByText(value);
-
-        expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('calc(100vh - 10px)');
-        expect(element.style.cursor).toBe('pointer');
-
-        jest.useFakeTimers();
-        fireEvent.mouseOver(element);
-        jest.runAllTimers();
-
-        expect(baseElement.querySelector('.ant-tooltip-open')).toBeInTheDocument();
-        expect(getAllByText(value).length).toBe(2);
     });
 });

--- a/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
+++ b/src/components/ellipsisText/__tests__/ellipsisText.test.tsx
@@ -26,14 +26,10 @@ describe('test ellipsis text if not set max width', () => {
                 cursor: 'pointer',
             })),
         });
-        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValueOnce({
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValue({
             width: 600,
         });
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} />
-            </div>
-        );
+        wrapper = render(<EllipsisText {...defaultProps} />);
     });
 
     afterEach(() => {
@@ -89,15 +85,17 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
 
 describe('test ellipsis text if set max width', () => {
     beforeEach(() => {
-        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValue({
-            width: 600,
-        });
         Object.defineProperty(window, 'getComputedStyle', {
             value: jest.fn(() => ({
                 paddingLeft: '0px',
                 paddingRight: '0px',
-                cursor: 'default',
+                cursor: 'pointer',
             })),
+        });
+        jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
+        jest.spyOn(document.documentElement, 'offsetWidth', 'get').mockImplementation(() => 600);
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValueOnce({
+            width: 900,
         });
     });
 
@@ -108,11 +106,7 @@ describe('test ellipsis text if set max width', () => {
 
     test('The maximum is a number, render correct value in ellipsis', () => {
         waitFor(() => {
-            wrapper = render(
-                <div>
-                    <EllipsisText {...defaultProps} maxWidth={100} />
-                </div>
-            );
+            wrapper = render(<EllipsisText {...defaultProps} maxWidth={100} />);
         });
         const { getByText, baseElement, getAllByText } = wrapper;
         const { value } = defaultProps;
@@ -132,19 +126,69 @@ describe('test ellipsis text if set max width', () => {
 
     test('The maximum is a string，render correct value in ellipsis', () => {
         waitFor(() => {
-            wrapper = render(
-                <div>
-                    <EllipsisText {...defaultProps} maxWidth="1000px" />
-                </div>
-            );
+            wrapper = render(<EllipsisText {...defaultProps} maxWidth="1000px" />);
         });
         const { getByText, baseElement } = wrapper;
         const { value } = defaultProps;
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('1000');
-        expect(element.style.cursor).toBe('default');
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
+
+        jest.useFakeTimers();
+        fireEvent.mouseOver(element);
+        jest.runAllTimers();
+
+        expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeInTheDocument();
+    });
+    test('The maximum is a percent，render correct value in ellipsis', () => {
+        waitFor(() => {
+            wrapper = render(<EllipsisText {...defaultProps} maxWidth="90%" />);
+        });
+        const { getByText, baseElement } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('810px');
+        expect(element.style.cursor).toBe('pointer');
+
+        jest.useFakeTimers();
+        fireEvent.mouseOver(element);
+        jest.runAllTimers();
+
+        expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeInTheDocument();
+    });
+    test('The maximum is a relative，render correct value in ellipsis', () => {
+        waitFor(() => {
+            wrapper = render(<EllipsisText {...defaultProps} maxWidth="calc(100% - 200px)" />);
+        });
+        const { getByText, baseElement } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('700px');
+        expect(element.style.cursor).toBe('pointer');
+
+        jest.useFakeTimers();
+        fireEvent.mouseOver(element);
+        jest.runAllTimers();
+
+        expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeInTheDocument();
+    });
+    test('The maximum is a not comply with the rules，render correct value in ellipsis', () => {
+        waitFor(() => {
+            wrapper = render(<EllipsisText {...defaultProps} maxWidth="20.4" />);
+        });
+        const { getByText, baseElement } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
 
         jest.useFakeTimers();
         fireEvent.mouseOver(element);

--- a/src/components/ellipsisText/index.tsx
+++ b/src/components/ellipsisText/index.tsx
@@ -63,16 +63,17 @@ const EllipsisText = (props: EllipsisTextProps) => {
      * @return {*}
      */
     const transitionWidth = (ele, maxWidth: string | number) => {
+        const eleWidth = getActualWidth(ele);
+
         if (typeof maxWidth === 'number') {
-            return maxWidth;
+            return maxWidth > eleWidth ? eleWidth : maxWidth; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
         }
 
         const numMatch = maxWidth.match(/^(\d+)(px)?$/);
         if (numMatch) {
-            return numMatch[1];
+            return +numMatch[1] > eleWidth ? eleWidth : +numMatch[1]; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
         }
 
-        const eleWidth = getActualWidth(ele);
         const percentMatch = maxWidth.match(/^(\d+)%$/);
         if (percentMatch) {
             return eleWidth * (parseInt(percentMatch[1]) / 100);
@@ -102,14 +103,15 @@ const EllipsisText = (props: EllipsisTextProps) => {
     const getContainerWidth = (ele: HTMLElement) => {
         if (!ele) return DEFAULT_MAX_WIDTH;
 
-        // 如果设置了最大宽度，则直接返回的宽度
-        if (maxWidth) {
-            return transitionWidth(ele, maxWidth);
-        }
         const { scrollWidth, parentElement } = ele;
+
         // 如果是行内元素，获取不到宽度，则向上寻找父元素
         if (scrollWidth === 0) {
             return getContainerWidth(parentElement);
+        }
+        // 如果设置了最大宽度，则直接返回的宽度
+        if (maxWidth) {
+            return transitionWidth(ele, maxWidth);
         }
 
         hideEleContent(ellipsisRef.current);

--- a/src/components/ellipsisText/index.tsx
+++ b/src/components/ellipsisText/index.tsx
@@ -1,7 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
 import { Tooltip } from 'antd';
-import Resize from '../resize';
 import { AbstractTooltipProps, RenderFunction } from 'antd/lib/tooltip';
+import classNames from 'classnames';
+import Resize from '../resize';
+import './style.scss';
 
 export interface EllipsisTextProps extends AbstractTooltipProps {
     value: string | number;
@@ -11,126 +13,200 @@ export interface EllipsisTextProps extends AbstractTooltipProps {
     [propName: string]: any;
 }
 
-const initialState = {
-    visible: false,
-    isEllipsis: false,
-    // eslint-disable-next-line no-void
-    actMaxWidth: void 0,
-};
-
-type State = typeof initialState;
-
 export interface NewHTMLElement extends HTMLElement {
     currentStyle?: CSSStyleDeclaration;
 }
 
 const DEFAULT_MAX_WIDTH = 120;
 
-export default class EllipsisText extends PureComponent<EllipsisTextProps, State> {
-    ellipsisRef: HTMLElement | null = null;
-    state = {
-        ...initialState,
+const EllipsisText = (props: EllipsisTextProps) => {
+    const { title, value, className, maxWidth, ...otherProps } = props;
+
+    const ellipsisRef = useRef<HTMLSpanElement>(null);
+
+    const [visible, setVisible] = useState(false);
+    const [width, setWidth] = useState(DEFAULT_MAX_WIDTH);
+    const [cursor, setCursor] = useState('default');
+
+    useLayoutEffect(() => {
+        onResize();
+    }, [value]);
+
+    /**
+     * @description: 根据属性名，获取dom的属性值
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getStyle = (dom: NewHTMLElement, attr: string) => {
+        // Compatible width IE8
+        return window?.getComputedStyle(dom)[attr] || dom.currentStyle[attr];
     };
 
-    componentDidMount() {
-        this.onResize();
-    }
+    /**
+     * @description: 根据属性名，获取dom的属性值为number的属性。如： height、width。。。
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getNumTypeStyleValue = (dom: NewHTMLElement, attr: string) => {
+        return parseInt(getStyle(dom, attr));
+    };
 
-    componentDidUpdate(preProps) {
-        const { value } = this.props;
-        if (value !== preProps.value) {
-            this.onResize();
+    /**
+     * @description: 10 -> 10,
+     * @description: 10px -> 10,
+     * @description: 90% -> ele.width * 0.9
+     * @description: calc(100% - 32px) -> ele.width - 32
+     * @param {*} ele
+     * @param {string & number} maxWidth
+     * @return {*}
+     */
+    const transitionWidth = (ele, maxWidth: string | number) => {
+        if (typeof maxWidth === 'number') {
+            return maxWidth;
         }
-    }
 
-    getRangeWidth = (ele: HTMLElement) => {
+        const numMatch = maxWidth.match(/^(\d+)(px)?$/);
+        if (numMatch) {
+            return numMatch[1];
+        }
+
+        const eleWidth = getActualWidth(ele);
+        const percentMatch = maxWidth.match(/^(\d+)%$/);
+        if (percentMatch) {
+            return eleWidth * (parseInt(percentMatch[1]) / 100);
+        }
+
+        const relativeMatch = maxWidth.match(/^calc\(100% - (\d+)px\)$/);
+        if (relativeMatch) {
+            return eleWidth - parseInt(relativeMatch[1]);
+        }
+
+        return eleWidth;
+    };
+
+    const hideEleContent = (node) => {
+        node.style.display = 'none';
+    };
+
+    const showEleContent = (node) => {
+        node.style.display = 'inline-block';
+    };
+
+    /**
+     * @description: 获取能够得到宽度的最近父元素宽度。行内元素无法获得宽度，需向上查找父元素
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getContainerWidth = (ele: HTMLElement) => {
+        if (!ele) return DEFAULT_MAX_WIDTH;
+
+        // 如果设置了最大宽度，则直接返回的宽度
+        if (maxWidth) {
+            return transitionWidth(ele, maxWidth);
+        }
+        const { scrollWidth, parentElement } = ele;
+        // 如果是行内元素，获取不到宽度，则向上寻找父元素
+        if (scrollWidth === 0) {
+            return getContainerWidth(parentElement);
+        }
+
+        hideEleContent(ellipsisRef.current);
+
+        const availableWidth = getAvailableWidth(ele);
+
+        return availableWidth < 0 ? 0 : availableWidth;
+    };
+
+    /**
+     * @description: 获取dom元素的内容宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getRangeWidth = (ele: HTMLElement): any => {
         const range = document.createRange();
         range.selectNodeContents(ele);
         const rangeWidth = range.getBoundingClientRect().width;
+
         return rangeWidth;
     };
 
-    getStyle = (dom: NewHTMLElement, attr: string) => {
-        // Compatible width IE8
-        const stylePadding = window?.getComputedStyle(dom)[attr] || dom.currentStyle[attr];
-
-        return parseInt(stylePadding.replace('px', ''));
+    /**
+     * @description: 获取元素不包括 padding 的宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getActualWidth = (ele: HTMLElement) => {
+        const width = ele.getBoundingClientRect().width;
+        const paddingLeft = getNumTypeStyleValue(ele, 'paddingLeft');
+        const paddingRight = getNumTypeStyleValue(ele, 'paddingRight');
+        return width - paddingLeft - paddingRight;
     };
 
-    // The nearest block parent element
-    getMaxWidth = (ele: HTMLElement) => {
-        // The default maximum width is 120px when the element does not exist
-        if (!ele) return DEFAULT_MAX_WIDTH;
-        const { scrollWidth, offsetWidth, parentElement } = ele;
-        // If inline element, find the parent element
-        if (scrollWidth === 0) {
-            return this.getMaxWidth(parentElement);
+    /**
+     * @description: 获取dom的可用宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getAvailableWidth = (ele: HTMLElement) => {
+        const width = getActualWidth(ele);
+        const contentWidth = getRangeWidth(ele);
+        const ellipsisWidth = width - contentWidth;
+        return ellipsisWidth;
+    };
+
+    /**
+     * @description: 计算父元素的宽度是否满足内容的大小
+     * @return {*}
+     */
+    const onResize = () => {
+        const ellipsisNode = ellipsisRef.current;
+        const rangeWidth = getRangeWidth(ellipsisNode);
+        const containerWidth = getContainerWidth(ellipsisNode.parentElement);
+        const visible = rangeWidth > containerWidth;
+        setVisible(visible);
+        setWidth(containerWidth);
+
+        const parentCursor = getStyle(ellipsisNode.parentElement, 'cursor');
+        if (parentCursor !== 'default') {
+            // 继承父元素的 hover 手势
+            setCursor(parentCursor);
+        } else {
+            // 截取文本时，则改变 hover 手势为 pointer
+            visible && setCursor('pointer');
         }
-        const ellipsisNode = this.ellipsisRef;
-        ellipsisNode.style.display = 'none';
-        // Get the width of elements other than omitted text
-        const rangeWidth = this.getRangeWidth(ele);
-        const ellipsisWidth =
-            offsetWidth -
-            rangeWidth -
-            this.getStyle(ele, 'paddingRight') -
-            this.getStyle(ele, 'paddingLeft');
 
-        return ellipsisWidth < 0 ? 0 : ellipsisWidth;
+        showEleContent(ellipsisRef.current);
     };
 
-    onResize = () => {
-        const { maxWidth } = this.props;
-        // if props has maxWidth don't have to calculate the text length
-        if (maxWidth) return;
-        const ellipsisNode = this.ellipsisRef;
-        const rangeWidth = this.getRangeWidth(ellipsisNode);
-        const ellipsisWidth = this.getMaxWidth(ellipsisNode.parentElement);
-        ellipsisNode.style.display = 'inline-block';
-        this.setState({
-            actMaxWidth: ellipsisWidth,
-            isEllipsis: rangeWidth > (maxWidth || ellipsisWidth),
-        });
-    };
-
-    // handleVisibleChange = (visible: boolean) => {
-    //   const { isEllipsis } = this.state;
-
-    //   this.setState({
-    //     visible: visible && isEllipsis
-    //   });
-    // };
-
-    render() {
-        const { actMaxWidth, isEllipsis } = this.state;
-        const { title, value, className, maxWidth, ...other } = this.props;
-
+    const renderText = useCallback(() => {
+        const style: React.CSSProperties = {
+            maxWidth: width,
+            cursor,
+        };
         return (
-            <Resize onResize={maxWidth ? null : this.onResize}>
-                <Tooltip
-                    title={title || value}
-                    // visible={visible}
-                    // onVisibleChange={this.handleVisibleChange}
-                    {...other}
-                >
-                    <span
-                        ref={(ref) => (this.ellipsisRef = ref)}
-                        className={className}
-                        style={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            display: 'inline-block',
-                            verticalAlign: 'bottom',
-                            minWidth: '2em',
-                            maxWidth: maxWidth || actMaxWidth,
-                            cursor: isEllipsis ? 'pointer' : 'default',
-                        }}
-                    >
-                        {value}
-                    </span>
-                </Tooltip>
-            </Resize>
+            <span
+                ref={ellipsisRef}
+                className={classNames('dtc-ellipsis-text', className)}
+                style={style}
+            >
+                {value}
+            </span>
         );
-    }
-}
+    }, [width, cursor, value]);
+
+    return (
+        <Resize onResize={onResize}>
+            {visible ? (
+                <Tooltip title={title || value} {...otherProps}>
+                    {renderText()}
+                </Tooltip>
+            ) : (
+                renderText()
+            )}
+        </Resize>
+    );
+};
+
+export default EllipsisText;

--- a/src/components/ellipsisText/style.scss
+++ b/src/components/ellipsisText/style.scss
@@ -1,0 +1,7 @@
+.dtc-ellipsis-text {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,6 +4,7 @@
 @import "../components/contextMenu/style.scss";
 @import "../components/copyIcon/style.scss";
 @import "../components/editCell/style.scss";
+@import "../components/ellipsisText/style.scss";
 @import "../components/fullscreen/style.scss";
 @import "../components/globalLoading/style.scss";
 @import "../components//markdownRender/theme/vs-dark.scss";


### PR DESCRIPTION
## 简介
本 PR 主要负责 ellipsisTest 组件的重构

## 主要变更
1. 自动识别内容宽度，与父元素宽度比较，如果比父元素宽度大，则展示 tootip 气泡，相反则不展示 tootip 气泡
2. 元素宽度统一使用 `getBoundingClientRect ().width` 获取。确保都为浮点型
3. 如果有传入 maxWidth。则以 maxWidth 为宽，否则以计算的父元素可用区域为宽
4. 如果父元素手势不为 `default`， 则继承父元素的手势。否则根据内容是否超出判断，未超出为`default`, 超出则为 `pointer`，

## 遗留问题
在无法拿到父元素宽度的情况下，会出现计算异常的问题。

## 用户侧：
需要确保父元素能够拿到宽度。
