### PR TITLE
Refactor/EllipsisTest

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ devDependencies:
   '@umijs/lint': 4.0.38_0745283bde06746ea70acc1818b56b12
   babel-plugin-import: 1.13.5
   babel-types: 6.26.0
-  dumi: 2.1.15_767a9676ad1704fa2e045c9614b146a0
+  dumi: 2.0.16_767a9676ad1704fa2e045c9614b146a0
   eslint: 8.30.0
   father: 4.1.1
   fetch-jsonp: 1.2.3
@@ -82,7 +82,7 @@ devDependencies:
   husky: 8.0.2
   jest: 29.3.1
   jest-environment-jsdom: 29.3.1
-  ko-lint-config: 2.2.18_jest@29.3.1+typescript@4.5.5
+  ko-lint-config: 2.2.16_jest@29.3.1+typescript@4.5.5
   lint-staged: 13.1.0
   prettier: 2.8.1
   prettier-plugin-organize-imports: 3.2.1_prettier@2.8.1+typescript@4.5.5
@@ -206,29 +206,6 @@ packages:
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
       '@babel/types': 7.20.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.2
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/core/7.21.0:
-    resolution: {integrity: sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.21.3
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.3
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -1308,26 +1285,6 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.20
-    dev: true
-
-  /@csstools/postcss-unset-value/1.0.2_postcss@8.4.21:
-    resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
-    engines: {node: ^12 || ^14 || >=16}
-    peerDependencies:
-      postcss: ^8.2
-    dependencies:
-      postcss: 8.4.21
-    dev: true
-
-  /@csstools/selector-specificity/2.0.2_b0132eb4833290a175e2a58939fd6432:
-    resolution: {integrity: sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==}
-    engines: {node: ^12 || ^14 || >=16}
-    peerDependencies:
-      postcss: ^8.2
-      postcss-selector-parser: ^6.0.10
-    dependencies:
-      postcss: 8.4.21
-      postcss-selector-parser: 6.0.11
     dev: true
 
   /@csstools/selector-specificity/2.0.2_d5e47c13600a2304adeb61035602f868:
@@ -3281,33 +3238,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.48.1_38b5877a6e91bdea6219e8c049e58805:
-    resolution: {integrity: sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.48.1_eslint@8.30.0+typescript@4.5.5
-      '@typescript-eslint/scope-manager': 5.48.1
-      '@typescript-eslint/type-utils': 5.48.1_eslint@8.30.0+typescript@4.5.5
-      '@typescript-eslint/utils': 5.48.1_eslint@8.30.0+typescript@4.5.5
-      debug: 4.3.4
-      eslint: 8.30.0
-      ignore: 5.2.2
-      natural-compare-lite: 1.4.0
-      regexpp: 3.2.0
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.30.0_eslint@8.22.0+typescript@4.5.5:
     resolution: {integrity: sha512-2oYYUws5o2liX6SrFQ5RB88+PuRymaM2EU02/9Ppoyu70vllPnHVO7ioxDdq/ypXHA277R04SVjxvwI8HmZpzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3392,14 +3322,6 @@ packages:
       '@typescript-eslint/visitor-keys': 5.46.1
     dev: true
 
-  /@typescript-eslint/scope-manager/5.48.1:
-    resolution: {integrity: sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.48.1
-      '@typescript-eslint/visitor-keys': 5.48.1
-    dev: true
-
   /@typescript-eslint/type-utils/5.30.0_eslint@8.22.0+typescript@4.5.5:
     resolution: {integrity: sha512-GF8JZbZqSS+azehzlv/lmQQ3EU3VfWYzCczdZjJRxSEeXDQkqFhCBgFhallLDbPwQOEQ4MHpiPfkjKk7zlmeNg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3431,26 +3353,6 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.5.5
       '@typescript-eslint/utils': 5.36.1_eslint@8.30.0+typescript@4.5.5
-      debug: 4.3.4
-      eslint: 8.30.0
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils/5.48.1_eslint@8.30.0+typescript@4.5.5:
-    resolution: {integrity: sha512-Hyr8HU8Alcuva1ppmqSYtM/Gp0q4JOp1F+/JH5D1IZm/bUBrV0edoewQZiEc1r6I8L4JL21broddxK8HAcZiqQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.5.5
-      '@typescript-eslint/utils': 5.48.1_eslint@8.30.0+typescript@4.5.5
       debug: 4.3.4
       eslint: 8.30.0
       tsutils: 3.21.0_typescript@4.5.5
@@ -3542,27 +3444,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.48.1_typescript@4.5.5:
-    resolution: {integrity: sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.48.1
-      '@typescript-eslint/visitor-keys': 5.48.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/utils/5.30.0_eslint@8.22.0+typescript@4.5.5:
     resolution: {integrity: sha512-0bIgOgZflLKIcZsWvfklsaQTM3ZUbmtH0rJ1hKyV3raoUYyeZwcjQ8ZUJTzS7KnhNcsVT1Rxs7zeeMHEhGlltw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3607,12 +3488,12 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.5.5
-      eslint: 8.22.0
+      '@typescript-eslint/scope-manager': 5.48.1
+      '@typescript-eslint/types': 5.48.1
+      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.5.5
+      eslint: 8.30.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.22.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -3630,26 +3511,6 @@ packages:
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.5.5
-      eslint: 8.30.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.30.0
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.48.1_eslint@8.30.0+typescript@4.5.5:
-    resolution: {integrity: sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.48.1
-      '@typescript-eslint/types': 5.48.1
-      '@typescript-eslint/typescript-estree': 5.48.1_typescript@4.5.5
       eslint: 8.30.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.30.0
@@ -3995,8 +3856,8 @@ packages:
       - supports-color
     dev: true
 
-  /@umijs/plugin-run/4.0.61:
-    resolution: {integrity: sha512-OzoU3CESoIesw0KaB7niQmUAZ1itVxTyeq8NXJ5ciXKSlQrgsR/rXYeq2KB6aEdzYLl7izNzOEF68Tty0hjsMQ==}
+  /@umijs/preset-umi/4.0.38_763916f4982bbc9f7649dcfbd9265ef5:
+    resolution: {integrity: sha512-C7/yY10rQR9qRFxiKrwY/sx8V8nrikNgFKnDmyxfUOpOF7Jup5sh+Wu6Y1whc6Vqhu3JphJJu40Iatc0r0Fo+w==}
     dependencies:
       tsx: 3.12.5
     dev: true
@@ -4014,15 +3875,14 @@ packages:
       '@umijs/core': 4.0.61
       '@umijs/did-you-know': 1.0.3
       '@umijs/history': 5.3.1
-      '@umijs/mfsu': 4.0.61
-      '@umijs/plugin-run': 4.0.61
-      '@umijs/renderer-react': 4.0.61_react-dom@18.1.0+react@18.1.0
-      '@umijs/server': 4.0.61
-      '@umijs/utils': 4.0.61
-      '@umijs/zod2ts': 4.0.61
+      '@umijs/mfsu': 4.0.38
+      '@umijs/plugin-run': 4.0.38
+      '@umijs/renderer-react': 4.0.38_react-dom@18.1.0+react@18.1.0
+      '@umijs/server': 4.0.38
+      '@umijs/utils': 4.0.38
       babel-plugin-dynamic-import-node: 2.3.3
       click-to-react-component: 1.0.8_d59151c832ab15b7856c709ec7c2cdd1
-      core-js: 3.28.0
+      core-js: 3.22.4
       current-script-polyfill: 1.0.0
       enhanced-resolve: 5.9.3
       fast-glob: 3.2.12
@@ -4033,7 +3893,7 @@ packages:
       react-dom: 18.1.0_react@18.1.0
       react-router: 6.3.0_react@18.1.0
       react-router-dom: 6.3.0_react-dom@18.1.0+react@18.1.0
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.13.9
     transitivePeerDependencies:
       - '@types/node'
       - '@types/react'
@@ -4056,19 +3916,34 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@umijs/renderer-react/4.0.61_react-dom@18.1.0+react@18.1.0:
-    resolution: {integrity: sha512-Fnhs31hoMJdcu/5KgzUaK9qs7sQPCe5t70hSKa4DYRTaPerBnSQpJIEtHUd5sr62EDFZHsLF3KlcPVIdhB4fdg==}
+  /@umijs/renderer-react/4.0.38_react-dom@18.1.0+react@18.1.0:
+    resolution: {integrity: sha512-8LrDEecCWj6YmKTeHP0+Kh7hMtiTtBcI1wqO0DItQI/QLTGGhJqnPYuwpKNmqUTKT2iATtc2ovw2cmQRGOYugA==}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.18.9
       '@loadable/component': 5.15.2_react@18.1.0
       history: 5.3.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
       react-helmet-async: 1.3.0_react-dom@18.1.0+react@18.1.0
       react-router-dom: 6.3.0_react-dom@18.1.0+react@18.1.0
+    dev: true
+
+  /@umijs/renderer-react/4.0.38_react-dom@18.2.0+react@18.2.0:
+    resolution: {integrity: sha512-8LrDEecCWj6YmKTeHP0+Kh7hMtiTtBcI1wqO0DItQI/QLTGGhJqnPYuwpKNmqUTKT2iATtc2ovw2cmQRGOYugA==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@babel/runtime': 7.18.9
+      '@loadable/component': 5.15.2_react@18.2.0
+      history: 5.3.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-helmet-async: 1.3.0_react-dom@18.2.0+react@18.2.0
+      react-router-dom: 6.3.0_react-dom@18.2.0+react@18.2.0
     dev: true
 
   /@umijs/renderer-react/4.0.61_react-dom@18.2.0+react@18.2.0:
@@ -6201,8 +6076,8 @@ packages:
     resolution: {integrity: sha512-a/Y5lf0G6gwsEQ9hop/n03CcjmHsGBk384Cz/AEX6mRYrfSpUx/lQvP9HLoXkCzScl9PL1sSmLPnMkgaXDCZLA==}
     dev: true
 
-  /dumi/2.1.15_767a9676ad1704fa2e045c9614b146a0:
-    resolution: {integrity: sha512-l8kuUI1mrYIBNWKoGieedoAwPPMhTtfX7Rcdut5PluvPF8h8LhmONZR420N0SQS9P4isP9tpVOBiYh48jJncjA==}
+  /dumi/2.0.16_767a9676ad1704fa2e045c9614b146a0:
+    resolution: {integrity: sha512-GpHtv8bVmiOcrEQHuN5rb4TUuOOZESkC4Jzkb2nP+3T3+lbh1248+K+YxwAzeoFiA5gx0DiYWnKQ0+NOmapIsA==}
     hasBin: true
     peerDependencies:
       react: '>=16.8'
@@ -6241,7 +6116,7 @@ packages:
       prism-themes: 1.9.0
       prismjs: 1.29.0
       raw-loader: 4.0.2
-      rc-tabs: 12.5.10_react-dom@18.2.0+react@18.2.0
+      rc-tabs: 12.1.0-alpha.1_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-copy-to-clipboard: 5.1.0_react@18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -6258,7 +6133,7 @@ packages:
       remark-rehype: 10.1.0
       sass: 1.57.0
       sitemap: 7.1.1
-      umi: 4.0.61_af1409dc9ee91956e9b68a20eac7d33e
+      umi: 4.0.38_af1409dc9ee91956e9b68a20eac7d33e
       unified: 10.1.2
       unist-util-visit: 4.1.1
       unist-util-visit-parents: 5.1.1
@@ -9965,8 +9840,8 @@ packages:
     resolution: {integrity: sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==}
     dev: true
 
-  /ko-lint-config/2.2.18_jest@29.3.1+typescript@4.5.5:
-    resolution: {integrity: sha512-ls5jymX9GjE8atROtwyoIpsOvjYSlXvHwoHH1sZqvJfrS5xHiy+zBe2KP67O1VNudRnIGyJb9J2QqkRdZyCSXA==}
+  /ko-lint-config/2.2.16_jest@29.3.1+typescript@4.5.5:
+    resolution: {integrity: sha512-bEOX/B56itgL9h9FIGTwoc5WXoSPL9HZ6UwVRKsXjShJ9N5ZzVdaOSaGcrgMb9FTfc/HarnvfK+1kiSmX9URhA==}
     engines: {node: '>=14'}
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.30.0_ae1d9fe1980ced49e1fd252e1d4332fe
@@ -13015,8 +12890,8 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier-plugin-organize-imports/3.2.1_prettier@2.8.1+typescript@4.5.5:
-    resolution: {integrity: sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==}
+  /prettier-plugin-organize-imports/2.3.4_prettier@2.8.1+typescript@4.5.5:
+    resolution: {integrity: sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
       '@volar/vue-typescript': ^1.0.4
@@ -13032,8 +12907,8 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /prettier-plugin-organize-imports/3.2.2_prettier@2.8.1+typescript@4.5.5:
-    resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
+  /prettier-plugin-organize-imports/3.2.1_prettier@2.8.1+typescript@4.5.5:
+    resolution: {integrity: sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
       '@volar/vue-typescript': ^1.0.4
@@ -13350,7 +13225,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       dom-align: 1.12.4
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       resize-observer-polyfill: 1.5.1
@@ -13366,7 +13241,7 @@ packages:
       classnames: 2.3.2
       rc-select: 14.1.16_react-dom@18.2.0+react@18.2.0
       rc-tree: 5.6.9_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13392,7 +13267,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
@@ -13407,7 +13282,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13421,7 +13296,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13435,7 +13310,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
@@ -13448,7 +13323,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       async-validator: 4.2.5
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13462,7 +13337,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-dialog: 8.9.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13475,7 +13350,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13488,7 +13363,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13504,7 +13379,7 @@ packages:
       rc-menu: 9.6.4_react-dom@18.2.0+react@18.2.0
       rc-textarea: 0.3.7_react-dom@18.2.0+react@18.2.0
       rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13520,27 +13395,11 @@ packages:
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
       rc-overflow: 1.2.8_react-dom@18.2.0+react@18.2.0
       rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
     dev: false
-
-  /rc-menu/9.8.2_react-dom@18.2.0+react@18.2.0:
-    resolution: {integrity: sha512-EahOJVjLuEnJsThoPN+mGnVm431RzVzDLZWHRS/YnXTQULa7OsgdJa/Y7qXxc3Z5sz8mgT6xYtgpmBXLxrZFaQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.21.0
-      classnames: 2.3.2
-      rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-overflow: 1.2.8_react-dom@18.2.0+react@18.2.0
-      rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    dev: true
 
   /rc-motion/2.6.2_react-dom@18.2.0+react@18.2.0:
     resolution: {integrity: sha512-4w1FaX3dtV749P8GwfS4fYnFG4Rb9pxvCYPc/b2fw1cmlHJWNNgOFIz7ysiD+eOrzJSvnLJWlNQQncpNMXwwpg==}
@@ -13550,7 +13409,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
@@ -13564,7 +13423,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13578,7 +13437,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
@@ -13607,7 +13466,7 @@ packages:
       dayjs: 1.11.7
       moment: 2.29.4
       rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
@@ -13621,7 +13480,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13635,7 +13494,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13648,7 +13507,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       resize-observer-polyfill: 1.5.1
@@ -13662,7 +13521,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13679,7 +13538,7 @@ packages:
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
       rc-overflow: 1.2.8_react-dom@18.2.0+react@18.2.0
       rc-trigger: 5.3.4_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       rc-virtual-list: 3.4.13_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -13694,7 +13553,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
@@ -13709,7 +13568,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13722,7 +13581,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13737,7 +13596,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
@@ -13755,13 +13614,13 @@ packages:
       rc-dropdown: 4.0.1_react-dom@18.2.0+react@18.2.0
       rc-menu: 9.6.4_react-dom@18.2.0+react@18.2.0
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /rc-tabs/12.5.10_react-dom@18.2.0+react@18.2.0:
-    resolution: {integrity: sha512-Ay0l0jtd4eXepFH9vWBvinBjqOpqzcsJTerBGwJy435P2S90Uu38q8U/mvc1sxUEVOXX5ZCFbxcWPnfG3dH+tQ==}
+  /rc-tabs/12.1.0-alpha.1_react-dom@18.2.0+react@18.2.0:
+    resolution: {integrity: sha512-M+B88WEnGSuE+mR54fpgPbZLAakzxa/H6FmEetLBl5WG4I3AcwSk9amuIPC/tu0KXBl+H6Bg5ZwrrEUOBUvgzg==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
@@ -13770,10 +13629,10 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-dropdown: 4.0.1_react-dom@18.2.0+react@18.2.0
-      rc-menu: 9.8.2_react-dom@18.2.0+react@18.2.0
+      rc-menu: 9.6.4_react-dom@18.2.0+react@18.2.0
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: true
@@ -13787,7 +13646,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shallowequal: 1.1.0
@@ -13816,7 +13675,7 @@ packages:
       classnames: 2.3.2
       rc-select: 14.1.16_react-dom@18.2.0+react@18.2.0
       rc-tree: 5.6.9_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13831,7 +13690,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       rc-virtual-list: 3.4.13_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -13848,7 +13707,7 @@ packages:
       classnames: 2.3.2
       rc-align: 4.0.15_react-dom@18.2.0+react@18.2.0
       rc-motion: 2.6.2_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
@@ -13860,7 +13719,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13878,17 +13737,6 @@ packages:
       shallowequal: 1.1.0
     dev: false
 
-  /rc-util/5.29.2_react-dom@18.2.0+react@18.2.0:
-    resolution: {integrity: sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    dependencies:
-      '@babel/runtime': 7.21.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-is: 16.13.1
-
   /rc-virtual-list/3.4.13_react-dom@18.2.0+react@18.2.0:
     resolution: {integrity: sha512-cPOVDmcNM7rH6ANotanMDilW/55XnFPw0Jh/GQYtrzZSy3AmWvCnqVNyNC/pgg3lfVmX2994dlzAhuUrd4jG7w==}
     engines: {node: '>=8.x'}
@@ -13899,7 +13747,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-resize-observer: 1.2.0_react-dom@18.2.0+react@18.2.0
-      rc-util: 5.29.2_react-dom@18.2.0+react@18.2.0
+      rc-util: 5.26.0_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -13967,7 +13815,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.18.9
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.1.0
@@ -13982,7 +13830,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.18.9
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.2.0
@@ -15791,23 +15639,23 @@ packages:
     hasBin: true
     dev: true
 
-  /umi/4.0.61_af1409dc9ee91956e9b68a20eac7d33e:
-    resolution: {integrity: sha512-NsmR1d7QzJ4ebRg6/B/DLNmy3f9wGLPcW3ysCWsuq9/WPas0NEKgAcqeOJQxdF3olsy0kfEs3xxU1Um7O/gQvA==}
+  /umi/4.0.38_af1409dc9ee91956e9b68a20eac7d33e:
+    resolution: {integrity: sha512-LXNvA7i+ESTtlrY6bd8ZutjECzZ0qONf6SDXaJq4pbuTHmsPWM1yDPy/ZSLfFOopnns2EG3A7V3TGaLycIrlrA==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.21.0
-      '@umijs/bundler-utils': 4.0.61
-      '@umijs/bundler-webpack': 4.0.61_typescript@4.5.5
-      '@umijs/core': 4.0.61
-      '@umijs/lint': 4.0.61_0745283bde06746ea70acc1818b56b12
-      '@umijs/preset-umi': 4.0.61_763916f4982bbc9f7649dcfbd9265ef5
-      '@umijs/renderer-react': 4.0.61_react-dom@18.2.0+react@18.2.0
-      '@umijs/server': 4.0.61
-      '@umijs/test': 4.0.61
-      '@umijs/utils': 4.0.61
-      prettier-plugin-organize-imports: 3.2.2_prettier@2.8.1+typescript@4.5.5
-      prettier-plugin-packagejson: 2.4.3_prettier@2.8.1
+      '@babel/runtime': 7.18.9
+      '@umijs/bundler-utils': 4.0.38
+      '@umijs/bundler-webpack': 4.0.38_typescript@4.5.5
+      '@umijs/core': 4.0.38
+      '@umijs/lint': 4.0.38_0745283bde06746ea70acc1818b56b12
+      '@umijs/preset-umi': 4.0.38_763916f4982bbc9f7649dcfbd9265ef5
+      '@umijs/renderer-react': 4.0.38_react-dom@18.2.0+react@18.2.0
+      '@umijs/server': 4.0.38
+      '@umijs/test': 4.0.38
+      '@umijs/utils': 4.0.38
+      prettier-plugin-organize-imports: 2.3.4_prettier@2.8.1+typescript@4.5.5
+      prettier-plugin-packagejson: 2.3.0_prettier@2.8.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'

--- a/src/ellipsisText/__tests__/ellipsisText.test.tsx
+++ b/src/ellipsisText/__tests__/ellipsisText.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { render, cleanup, fireEvent, RenderResult } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import EllipsisText from '../index';
 
-(window as any).document.createRange = () => ({
+(global as any).document.createRange = () => ({
     selectNodeContents: jest.fn(),
     getBoundingClientRect: jest.fn(() => ({
         width: 500,
@@ -14,7 +14,7 @@ const defaultProps = {
     value: '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本',
 };
 
-let wrapper: any, element: any;
+let wrapper: RenderResult, element;
 describe('test ellipsis text if not set max width', () => {
     beforeEach(() => {
         jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
@@ -23,14 +23,13 @@ describe('test ellipsis text if not set max width', () => {
             value: jest.fn(() => ({
                 paddingLeft: '0px',
                 paddingRight: '0px',
+                cursor: 'pointer',
             })),
         });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} />
-            </div>
-        );
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValue({
+            width: 600,
+        });
+        wrapper = render(<EllipsisText {...defaultProps} />);
     });
 
     afterEach(() => {
@@ -46,6 +45,15 @@ describe('test ellipsis text if not set max width', () => {
         expect(element).toBeInTheDocument();
         expect(element.style.maxWidth).toBe('100px');
     });
+
+    test('render correct hover cursor in ellipsis', () => {
+        const { getByText } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.cursor).toBe('pointer');
+    });
 });
 
 describe('auto calculate ellipsis text if the parent element does not exist', () => {
@@ -54,6 +62,7 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
             value: jest.fn(() => ({
                 paddingLeft: '0px',
                 paddingRight: '0px',
+                cursor: 'pointer',
             })),
         });
 
@@ -77,18 +86,17 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
 describe('test ellipsis text if set max width', () => {
     beforeEach(() => {
         Object.defineProperty(window, 'getComputedStyle', {
-            value: () => ({
-                getPropertyValue: (_prop: any) => {
-                    return '';
-                },
-            }),
+            value: jest.fn(() => ({
+                paddingLeft: '0px',
+                paddingRight: '0px',
+                cursor: 'pointer',
+            })),
         });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} maxWidth={100} />
-            </div>
-        );
+        jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
+        jest.spyOn(document.documentElement, 'offsetWidth', 'get').mockImplementation(() => 600);
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValueOnce({
+            width: 900,
+        });
     });
 
     afterEach(() => {
@@ -96,60 +104,92 @@ describe('test ellipsis text if set max width', () => {
         jest.restoreAllMocks();
     });
 
-    test('render correct value in ellipsis', () => {
-        const { getByText } = wrapper;
+    test('The maximum is a number, render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth={100} />
+        );
+
         const { value } = defaultProps;
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
         expect(element.style.maxWidth).toBe('100px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+        expect(getAllByText(value).length).toBe(2);
+
+        fireEvent.mouseLeave(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
     });
 
-    test('render correct prompt info if mouse hover the text ', async () => {
-        const { getByText, getAllByText, container } = wrapper;
-        const { value } = defaultProps;
-        element = getByText(value);
-
-        jest.useFakeTimers();
-        fireEvent.mouseOver(element);
-        jest.runAllTimers();
-
-        await waitFor(() => {
-            expect(container.querySelector('.ant-tooltip-open')).toBeInTheDocument();
-            expect(getAllByText(value).length).toBe(2);
-        });
-    });
-});
-
-describe('test ellipsis text if in IE8', () => {
-    beforeEach(() => {
-        jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
-        jest.spyOn(document.documentElement, 'offsetWidth', 'get').mockImplementation(() => 100);
-        Object.defineProperty(document.documentElement, 'currentStyle', {
-            value: {
-                paddingLeft: '0px',
-                paddingRight: '0px',
-            },
-        });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} />
-            </div>
+    test('The maximum is a string，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="1000px" />
         );
-    });
-
-    afterEach(() => {
-        cleanup();
-        jest.restoreAllMocks();
-    });
-
-    test('render correct value in ellipsis', () => {
-        const { getByText } = wrapper;
         const { value } = defaultProps;
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('0');
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a percent，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="90%" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('810px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a relative，render correct value in ellipsis', () => {
+        const { container, getAllByText, getByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="calc(100% - 200px)" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('700px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a not comply with the rules，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="20.4" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
     });
 });

--- a/src/ellipsisText/demos/basic.tsx
+++ b/src/ellipsisText/demos/basic.tsx
@@ -5,7 +5,6 @@ export default () => {
     return (
         <EllipsisText
             value={'我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'}
-            maxWidth={200}
         />
     );
 };

--- a/src/ellipsisText/demos/flex.tsx
+++ b/src/ellipsisText/demos/flex.tsx
@@ -5,21 +5,29 @@ import { EllipsisText } from 'dt-react-component';
 export default () => {
     return (
         <>
-            <div>
+            <div
+                style={{
+                    display: 'flex',
+                }}
+            >
                 <EllipsisText
                     value={
                         '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
                     }
-                    maxWidth={200}
                 />
+                我是来捣乱的
             </div>
             <Divider />
-            <div>
+            <div
+                style={{
+                    display: 'flex',
+                }}
+            >
+                我是来捣乱的
                 <EllipsisText
                     value={
                         '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
                     }
-                    maxWidth={'30%'}
                 />
             </div>
         </>

--- a/src/ellipsisText/demos/inlineElement.tsx
+++ b/src/ellipsisText/demos/inlineElement.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { EllipsisText } from 'dt-react-component';
+
+export default () => {
+    return (
+        <div
+            style={{
+                width: 200,
+            }}
+        >
+            <span>
+                <EllipsisText
+                    value={
+                        '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                    }
+                />
+            </span>
+        </div>
+    );
+};

--- a/src/ellipsisText/demos/multiple.tsx
+++ b/src/ellipsisText/demos/multiple.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { EllipsisText } from 'dt-react-component';
+
+export default () => {
+    return (
+        <div
+            style={{
+                width: '100%',
+            }}
+        >
+            <EllipsisText
+                value={
+                    '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                }
+                maxWidth={200}
+            />
+            <EllipsisText
+                value={
+                    '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                }
+                maxWidth={'calc(100% - 200px)'}
+            />
+        </div>
+    );
+};

--- a/src/ellipsisText/index.md
+++ b/src/ellipsisText/index.md
@@ -10,18 +10,19 @@ demo:
 
 ## 何时使用
 
-用于长文本省略，根据最近块级父元素自动计算文本最大宽度，也可以手动传最大宽度，当传入 maxWidth 时不会去动态计算文本宽度，hover 显示完整内容。
+用于长文本省略，根据最近块级父元素自动计算文本最大宽度，也可以手动传最大宽度，hover 显示完整内容。
 
--   自动计算宽度仅限于最近块级父元素下都为行内元素
--   如果最近块级元素为行内块级元素，必须设置宽度
--   使用 antd table 当表头 fixed：true 时，请传 maxWidth
--   某个元素下使用多个 EllipsisText 最好传 maxWidth
--   大批量数据使用时最好传 maxWidth，防止出现性能问题
+## 注意
+
+-   宽度的计算过程是一个比较耗时的动作，同一页面内该组件使用次数保持在 100 个以内，如果存在性能问题，考虑先支持虚拟滚动等技术后，在使用该组件。
 
 ## 示例
 
-<code src="./demos/basic.tsx" title="基础使用"></code>
-<code src="./demos/maxWidth.tsx" title="进阶使用" description="请更改窗口大小"></code>
+<code src="./demos/basic.tsx" title="基础使用" description="请更改窗口大小"></code>
+<code src="./demos/maxWidth.tsx" title="宽度限制" ></code>
+<code src="./demos/inlineElement.tsx" title="行内元素" description="行内元素无法获得宽度，在计算时会不断向上查找，直到找到一个能够正确获取宽度的父元素，并以找到父元素宽度当作文本的可视宽度" ></code>
+<code src="./demos/flex.tsx" title="flex" description="请更改窗口大小"></code>
+<code src="./demos/multiple.tsx" title="同一容器多个 EllipsisText 组件" description="都必须传入 maxWidth"></code>
 
 ## API
 
@@ -30,8 +31,8 @@ demo:
 | value     | 显示文本内容                       | `string \| number` | -      |
 | className | 为文本内容所在节点添加自定义样式名 | `string`           | -      |
 | maxWidth  | 文本内容的最大宽度                 | `string \| number` | -      |
-| title     | 提示文字                           | `string \| number` | -      |
+| title     | 提示文字                           | `ReactNode`        | -      |
 
 :::info
-其余参数继承自 [继承 antd3.x 的 Tooltip](https://3x.ant.design/components/tooltip-cn/#header)
+其余参数继承自 [继承 antd4.x 的 Tooltip](https://4x.ant.design/components/tooltip-cn/#API)
 :::

--- a/src/ellipsisText/index.tsx
+++ b/src/ellipsisText/index.tsx
@@ -110,7 +110,7 @@ const EllipsisText = (props: EllipsisTextProps) => {
         if (scrollWidth === 0) {
             return getContainerWidth(parentElement!);
         }
-        // 如果设置了最大宽度，则直接返回的宽度
+        // 如果设置了最大宽度，则直接返回宽度
         if (maxWidth) {
             return transitionWidth(ele, maxWidth);
         }

--- a/src/ellipsisText/index.tsx
+++ b/src/ellipsisText/index.tsx
@@ -1,7 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
 import { Tooltip } from 'antd';
-import Resize from '../resize';
 import { AbstractTooltipProps, RenderFunction } from 'antd/lib/tooltip';
+import classNames from 'classnames';
+import Resize from '../resize';
+import './style.scss';
 
 export interface EllipsisTextProps extends AbstractTooltipProps {
     value: string | number;
@@ -11,126 +13,207 @@ export interface EllipsisTextProps extends AbstractTooltipProps {
     [propName: string]: any;
 }
 
-const initialState = {
-    visible: false,
-    isEllipsis: false,
-    // eslint-disable-next-line no-void
-    actMaxWidth: void 0,
-};
-
-type State = Omit<typeof initialState, 'actMaxWidth'> & { actMaxWidth?: number };
-
 export interface NewHTMLElement extends HTMLElement {
     currentStyle?: CSSStyleDeclaration;
 }
 
 const DEFAULT_MAX_WIDTH = 120;
 
-export default class EllipsisText extends PureComponent<EllipsisTextProps, State> {
-    ellipsisRef: HTMLElement | null = null;
-    state = {
-        ...initialState,
+const EllipsisText = (props: EllipsisTextProps) => {
+    const { title, value, className, maxWidth, ...otherProps } = props;
+
+    const ellipsisRef = useRef<HTMLSpanElement>(null);
+
+    const [visible, setVisible] = useState(false);
+    const [width, setWidth] = useState<number | string>(DEFAULT_MAX_WIDTH);
+    const [cursor, setCursor] = useState('default');
+
+    useLayoutEffect(() => {
+        onResize();
+    }, [value]);
+
+    /**
+     * @description: 根据属性名，获取dom的属性值
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getStyle = (dom: NewHTMLElement, attr: string) => {
+        // Compatible width IE8
+        // @ts-ignore
+        return window.getComputedStyle(dom)[attr] || dom.currentStyle[attr];
     };
 
-    componentDidMount() {
-        this.onResize();
-    }
+    /**
+     * @description: 根据属性名，获取dom的属性值为number的属性。如： height、width。。。
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getNumTypeStyleValue = (dom: NewHTMLElement, attr: string) => {
+        return parseInt(getStyle(dom, attr));
+    };
 
-    componentDidUpdate(preProps: EllipsisTextProps) {
-        const { value } = this.props;
-        if (value !== preProps.value) {
-            this.onResize();
+    /**
+     * @description: 10 -> 10,
+     * @description: 10px -> 10,
+     * @description: 90% -> ele.width * 0.9
+     * @description: calc(100% - 32px) -> ele.width - 32
+     * @param {*} ele
+     * @param {string & number} maxWidth
+     * @return {*}
+     */
+    const transitionWidth = (ele: HTMLElement, maxWidth: string | number) => {
+        const eleWidth = getActualWidth(ele);
+
+        if (typeof maxWidth === 'number') {
+            return maxWidth > eleWidth ? eleWidth : maxWidth; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
         }
-    }
 
-    getRangeWidth = (ele: HTMLElement) => {
+        const numMatch = maxWidth.match(/^(\d+)(px)?$/);
+        if (numMatch) {
+            return +numMatch[1] > eleWidth ? eleWidth : +numMatch[1]; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
+        }
+
+        const percentMatch = maxWidth.match(/^(\d+)%$/);
+        if (percentMatch) {
+            return eleWidth * (parseInt(percentMatch[1]) / 100);
+        }
+
+        const relativeMatch = maxWidth.match(/^calc\(100% - (\d+)px\)$/);
+        if (relativeMatch) {
+            return eleWidth - parseInt(relativeMatch[1]);
+        }
+
+        return eleWidth;
+    };
+
+    const hideEleContent = (node: HTMLElement) => {
+        node.style.display = 'none';
+    };
+
+    const showEleContent = (node: HTMLElement) => {
+        node.style.display = 'inline-block';
+    };
+
+    /**
+     * @description: 获取能够得到宽度的最近父元素宽度。行内元素无法获得宽度，需向上查找父元素
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getContainerWidth = (ele: HTMLElement): number | string => {
+        if (!ele) return DEFAULT_MAX_WIDTH;
+
+        const { scrollWidth, parentElement } = ele;
+
+        // 如果是行内元素，获取不到宽度，则向上寻找父元素
+        if (scrollWidth === 0) {
+            return getContainerWidth(parentElement!);
+        }
+        // 如果设置了最大宽度，则直接返回的宽度
+        if (maxWidth) {
+            return transitionWidth(ele, maxWidth);
+        }
+
+        hideEleContent(ellipsisRef.current!);
+
+        const availableWidth = getAvailableWidth(ele);
+
+        return availableWidth < 0 ? 0 : availableWidth;
+    };
+
+    /**
+     * @description: 获取dom元素的内容宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getRangeWidth = (ele: HTMLElement): any => {
         const range = document.createRange();
         range.selectNodeContents(ele);
         const rangeWidth = range.getBoundingClientRect().width;
+
         return rangeWidth;
     };
 
-    getStyle = (dom: NewHTMLElement, attr: any) => {
-        // Compatible width IE8
-        const stylePadding = window?.getComputedStyle(dom)[attr] || dom.currentStyle?.[attr] || '';
-
-        return parseInt(stylePadding.replace('px', ''));
+    /**
+     * @description: 获取元素不包括 padding 的宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getActualWidth = (ele: HTMLElement) => {
+        const width = ele.getBoundingClientRect().width;
+        const paddingLeft = getNumTypeStyleValue(ele, 'paddingLeft');
+        const paddingRight = getNumTypeStyleValue(ele, 'paddingRight');
+        return width - paddingLeft - paddingRight;
     };
 
-    // The nearest block parent element
-    getMaxWidth = (ele: HTMLElement): number => {
-        // The default maximum width is 120px when the element does not exist
-        if (!ele) return DEFAULT_MAX_WIDTH;
-        const { scrollWidth, offsetWidth, parentElement } = ele;
-        // If inline element, find the parent element
-        if (scrollWidth === 0) {
-            return this.getMaxWidth(parentElement!);
+    /**
+     * @description: 获取dom的可用宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getAvailableWidth = (ele: HTMLElement) => {
+        const width = getActualWidth(ele);
+        const contentWidth = getRangeWidth(ele);
+        const ellipsisWidth = width - contentWidth;
+        return ellipsisWidth;
+    };
+
+    /**
+     * @description: 计算父元素的宽度是否满足内容的大小
+     * @return {*}
+     */
+    const onResize = () => {
+        const ellipsisNode = ellipsisRef.current!;
+        const parentElement = ellipsisNode.parentElement!;
+        const rangeWidth = getRangeWidth(ellipsisNode);
+        const containerWidth = getContainerWidth(parentElement);
+        const visible = rangeWidth > containerWidth;
+        setVisible(visible);
+        setWidth(containerWidth);
+        const parentCursor = getStyle(parentElement, 'cursor');
+        if (parentCursor !== 'default') {
+            // 继承父元素的 hover 手势
+            setCursor(parentCursor);
+        } else {
+            // 截取文本时，则改变 hover 手势为 pointer
+            visible && setCursor('pointer');
         }
-        const ellipsisNode = this.ellipsisRef!;
-        ellipsisNode.style.display = 'none';
-        // Get the width of elements other than omitted text
-        const rangeWidth = this.getRangeWidth(ele);
-        const ellipsisWidth =
-            offsetWidth -
-            rangeWidth -
-            this.getStyle(ele, 'paddingRight') -
-            this.getStyle(ele, 'paddingLeft');
-
-        return ellipsisWidth < 0 ? 0 : ellipsisWidth;
+        showEleContent(ellipsisNode);
     };
 
-    onResize = () => {
-        const { maxWidth } = this.props;
-        // if props has maxWidth don't have to calculate the text length
-        if (maxWidth) return;
-        const ellipsisNode = this.ellipsisRef!;
-        const rangeWidth = this.getRangeWidth(ellipsisNode);
-        const ellipsisWidth = this.getMaxWidth(ellipsisNode.parentElement!);
-        ellipsisNode.style.display = 'inline-block';
-        this.setState({
-            actMaxWidth: ellipsisWidth,
-            isEllipsis: rangeWidth > (maxWidth || ellipsisWidth),
-        });
-    };
-
-    // handleVisibleChange = (visible: boolean) => {
-    //   const { isEllipsis } = this.state;
-
-    //   this.setState({
-    //     visible: visible && isEllipsis
-    //   });
-    // };
-
-    render() {
-        const { actMaxWidth, isEllipsis } = this.state;
-        const { title, value, className, maxWidth, ...other } = this.props;
-
+    const renderText = useCallback(() => {
+        const style: React.CSSProperties = {
+            maxWidth: width,
+            cursor,
+        };
         return (
-            <Resize onResize={maxWidth ? undefined : this.onResize}>
+            <span
+                ref={ellipsisRef}
+                className={classNames('dtc-ellipsis-text', className)}
+                style={style}
+            >
+                {value}
+            </span>
+        );
+    }, [width, cursor, value]);
+
+    return (
+        <Resize onResize={onResize}>
+            {visible ? (
                 <Tooltip
                     title={title || value}
-                    // visible={visible}
-                    // onVisibleChange={this.handleVisibleChange}
-                    {...other}
+                    mouseEnterDelay={0}
+                    mouseLeaveDelay={0}
+                    {...otherProps}
                 >
-                    <span
-                        ref={(ref) => (this.ellipsisRef = ref)}
-                        className={className}
-                        style={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            display: 'inline-block',
-                            verticalAlign: 'bottom',
-                            minWidth: '2em',
-                            maxWidth: maxWidth || actMaxWidth,
-                            cursor: isEllipsis ? 'pointer' : 'default',
-                        }}
-                    >
-                        {value}
-                    </span>
+                    {renderText()}
                 </Tooltip>
-            </Resize>
-        );
-    }
-}
+            ) : (
+                renderText()
+            )}
+        </Resize>
+    );
+};
+
+export default EllipsisText;

--- a/src/ellipsisText/style.scss
+++ b/src/ellipsisText/style.scss
@@ -1,0 +1,7 @@
+.dtc-ellipsis-text {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+}


### PR DESCRIPTION
简介
本 PR 主要负责 ellipsisTest 组件的重构

主要变更
自动识别内容宽度，与父元素宽度比较，如果比父元素宽度大，则展示 tootip 气泡，相反则不展示 tootip 气泡
元素宽度统一使用 getBoundingClientRect ().width 获取。确保都为浮点型
如果有传入 maxWidth。则以 maxWidth 为宽，否则以计算的父元素可用区域为宽
如果父元素手势不为 default， 则继承父元素的手势。否则根据内容是否超出判断，未超出为default, 超出则为 pointer，
遗留问题
在无法拿到父元素宽度的情况下，会出现计算异常的问题。

用户侧：
需要确保父元素能够拿到宽度。

预览：
https://zaoei.github.io/dt-react-component/components/ellipsis-text