### PR TITLE
refactor: ellipsisTest component, improve documentation

### DIFF
--- a/src/ellipsisText/__tests__/ellipsisText.test.tsx
+++ b/src/ellipsisText/__tests__/ellipsisText.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { render, cleanup, fireEvent, RenderResult } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import EllipsisText from '../index';
 
-(window as any).document.createRange = () => ({
+(global as any).document.createRange = () => ({
     selectNodeContents: jest.fn(),
     getBoundingClientRect: jest.fn(() => ({
         width: 500,
@@ -14,7 +14,7 @@ const defaultProps = {
     value: '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本',
 };
 
-let wrapper: any, element: any;
+let wrapper: RenderResult, element;
 describe('test ellipsis text if not set max width', () => {
     beforeEach(() => {
         jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
@@ -23,14 +23,13 @@ describe('test ellipsis text if not set max width', () => {
             value: jest.fn(() => ({
                 paddingLeft: '0px',
                 paddingRight: '0px',
+                cursor: 'pointer',
             })),
         });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} />
-            </div>
-        );
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValue({
+            width: 600,
+        });
+        wrapper = render(<EllipsisText {...defaultProps} />);
     });
 
     afterEach(() => {
@@ -46,6 +45,15 @@ describe('test ellipsis text if not set max width', () => {
         expect(element).toBeInTheDocument();
         expect(element.style.maxWidth).toBe('100px');
     });
+
+    test('render correct hover cursor in ellipsis', () => {
+        const { getByText } = wrapper;
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.cursor).toBe('pointer');
+    });
 });
 
 describe('auto calculate ellipsis text if the parent element does not exist', () => {
@@ -54,6 +62,7 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
             value: jest.fn(() => ({
                 paddingLeft: '0px',
                 paddingRight: '0px',
+                cursor: 'pointer',
             })),
         });
 
@@ -77,18 +86,17 @@ describe('auto calculate ellipsis text if the parent element does not exist', ()
 describe('test ellipsis text if set max width', () => {
     beforeEach(() => {
         Object.defineProperty(window, 'getComputedStyle', {
-            value: () => ({
-                getPropertyValue: (_prop: any) => {
-                    return '';
-                },
-            }),
+            value: jest.fn(() => ({
+                paddingLeft: '0px',
+                paddingRight: '0px',
+                cursor: 'pointer',
+            })),
         });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} maxWidth={100} />
-            </div>
-        );
+        jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
+        jest.spyOn(document.documentElement, 'offsetWidth', 'get').mockImplementation(() => 600);
+        document.documentElement.getBoundingClientRect = jest.fn().mockReturnValueOnce({
+            width: 900,
+        });
     });
 
     afterEach(() => {
@@ -96,60 +104,92 @@ describe('test ellipsis text if set max width', () => {
         jest.restoreAllMocks();
     });
 
-    test('render correct value in ellipsis', () => {
-        const { getByText } = wrapper;
+    test('The maximum is a number, render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth={100} />
+        );
+
         const { value } = defaultProps;
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
         expect(element.style.maxWidth).toBe('100px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+        expect(getAllByText(value).length).toBe(2);
+
+        fireEvent.mouseLeave(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
     });
 
-    test('render correct prompt info if mouse hover the text ', async () => {
-        const { getByText, getAllByText, container } = wrapper;
-        const { value } = defaultProps;
-        element = getByText(value);
-
-        jest.useFakeTimers();
-        fireEvent.mouseOver(element);
-        jest.runAllTimers();
-
-        await waitFor(() => {
-            expect(container.querySelector('.ant-tooltip-open')).toBeInTheDocument();
-            expect(getAllByText(value).length).toBe(2);
-        });
-    });
-});
-
-describe('test ellipsis text if in IE8', () => {
-    beforeEach(() => {
-        jest.spyOn(document.documentElement, 'scrollWidth', 'get').mockImplementation(() => 100);
-        jest.spyOn(document.documentElement, 'offsetWidth', 'get').mockImplementation(() => 100);
-        Object.defineProperty(document.documentElement, 'currentStyle', {
-            value: {
-                paddingLeft: '0px',
-                paddingRight: '0px',
-            },
-        });
-
-        wrapper = render(
-            <div>
-                <EllipsisText {...defaultProps} />
-            </div>
+    test('The maximum is a string，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="1000px" />
         );
-    });
-
-    afterEach(() => {
-        cleanup();
-        jest.restoreAllMocks();
-    });
-
-    test('render correct value in ellipsis', () => {
-        const { getByText } = wrapper;
         const { value } = defaultProps;
         element = getByText(value);
 
         expect(element).toBeInTheDocument();
-        expect(element.style.maxWidth).toBe('0');
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a percent，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="90%" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('810px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a relative，render correct value in ellipsis', () => {
+        const { container, getAllByText, getByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="calc(100% - 200px)" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('700px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
+    });
+    test('The maximum is a not comply with the rules，render correct value in ellipsis', () => {
+        const { container, getByText, getAllByText } = render(
+            <EllipsisText {...defaultProps} maxWidth="20.4" />
+        );
+        const { value } = defaultProps;
+        element = getByText(value);
+
+        expect(element).toBeInTheDocument();
+        expect(element.style.maxWidth).toBe('900px');
+        expect(element.style.cursor).toBe('pointer');
+
+        fireEvent.mouseEnter(element);
+        expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+        expect(getAllByText(value).length).toBe(1);
+
+        fireEvent.mouseLeave(element);
     });
 });

--- a/src/ellipsisText/demos/basic.tsx
+++ b/src/ellipsisText/demos/basic.tsx
@@ -5,7 +5,6 @@ export default () => {
     return (
         <EllipsisText
             value={'我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'}
-            maxWidth={200}
         />
     );
 };

--- a/src/ellipsisText/demos/flex.tsx
+++ b/src/ellipsisText/demos/flex.tsx
@@ -5,21 +5,29 @@ import { EllipsisText } from 'dt-react-component';
 export default () => {
     return (
         <>
-            <div>
+            <div
+                style={{
+                    display: 'flex',
+                }}
+            >
                 <EllipsisText
                     value={
                         '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
                     }
-                    maxWidth={200}
                 />
+                我是来捣乱的
             </div>
             <Divider />
-            <div>
+            <div
+                style={{
+                    display: 'flex',
+                }}
+            >
+                我是来捣乱的
                 <EllipsisText
                     value={
                         '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
                     }
-                    maxWidth={'30%'}
                 />
             </div>
         </>

--- a/src/ellipsisText/demos/inlineElement.tsx
+++ b/src/ellipsisText/demos/inlineElement.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { EllipsisText } from 'dt-react-component';
+
+export default () => {
+    return (
+        <div
+            style={{
+                width: 200,
+            }}
+        >
+            <span>
+                <EllipsisText
+                    value={
+                        '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                    }
+                />
+            </span>
+        </div>
+    );
+};

--- a/src/ellipsisText/demos/maxWidth.tsx
+++ b/src/ellipsisText/demos/maxWidth.tsx
@@ -1,27 +1,31 @@
-import React from 'react';
-import { Divider } from 'antd';
+import React, { useState } from 'react';
+import { Radio, RadioChangeEvent, Divider } from 'antd';
 import { EllipsisText } from 'dt-react-component';
 
 export default () => {
+    const [width, setWidth] = useState(200);
+
+    const onChange = (e: RadioChangeEvent) => {
+        setWidth(e.target.value);
+    };
+
     return (
         <>
-            <div>
-                <EllipsisText
-                    value={
-                        '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
-                    }
-                    maxWidth={200}
-                />
-            </div>
+            <Radio.Group onChange={onChange} value={width}>
+                <Radio value={200}>200px</Radio>
+                <Radio value={300}>300px</Radio>
+                <Radio value={'20%'}>20%</Radio>
+                <Radio value={'50%'}>50%</Radio>
+                <Radio value={'100%'}>100%</Radio>
+                <Radio value={'calc(100% - 100px)'}>calc(100% - 100px)%</Radio>
+            </Radio.Group>
             <Divider />
-            <div>
-                <EllipsisText
-                    value={
-                        '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
-                    }
-                    maxWidth={'30%'}
-                />
-            </div>
+            <EllipsisText
+                value={
+                    '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                }
+                maxWidth={width}
+            />
         </>
     );
 };

--- a/src/ellipsisText/demos/multiple.tsx
+++ b/src/ellipsisText/demos/multiple.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { EllipsisText } from 'dt-react-component';
+
+export default () => {
+    return (
+        <div
+            style={{
+                width: '100%',
+            }}
+        >
+            <EllipsisText
+                value={
+                    '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                }
+                maxWidth={200}
+            />
+            <EllipsisText
+                value={
+                    '我是很长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本'
+                }
+                maxWidth={'calc(100% - 200px)'}
+            />
+        </div>
+    );
+};

--- a/src/ellipsisText/demos/valueType.tsx
+++ b/src/ellipsisText/demos/valueType.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { EllipsisText } from 'dt-react-component';
+import { Divider } from 'antd';
+
+const element = (
+    <>
+        我是很长长长长长长
+        <span
+            style={{
+                color: 'red',
+            }}
+        >
+            长长长长长长长长长长长长长长
+        </span>
+        长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长的文本
+    </>
+);
+
+const useEllipsisText = () => element;
+
+class WithEllipsisText extends React.Component {
+    render(): React.ReactNode {
+        return element;
+    }
+}
+
+export default () => {
+    return (
+        <>
+            <Divider orientation="left">Element</Divider>
+            <div
+                style={{
+                    width: '70%',
+                }}
+            >
+                <EllipsisText value={useEllipsisText} />
+            </div>
+            <Divider orientation="left">Hooks</Divider>
+            <div
+                style={{
+                    width: '50%',
+                }}
+            >
+                <EllipsisText value={useEllipsisText} />
+            </div>
+            <Divider orientation="left">Class</Divider>
+            <div
+                style={{
+                    width: '20%',
+                }}
+            >
+                <EllipsisText value={<WithEllipsisText />} />
+            </div>
+        </>
+    );
+};

--- a/src/ellipsisText/index.md
+++ b/src/ellipsisText/index.md
@@ -10,18 +10,19 @@ demo:
 
 ## 何时使用
 
-用于长文本省略，根据最近块级父元素自动计算文本最大宽度，也可以手动传最大宽度，当传入 maxWidth 时不会去动态计算文本宽度，hover 显示完整内容。
+用于长文本省略，根据最近块级父元素自动计算文本最大宽度，也可以手动传最大宽度，hover 显示完整内容。
 
--   自动计算宽度仅限于最近块级父元素下都为行内元素
--   如果最近块级元素为行内块级元素，必须设置宽度
--   使用 antd table 当表头 fixed：true 时，请传 maxWidth
--   某个元素下使用多个 EllipsisText 最好传 maxWidth
--   大批量数据使用时最好传 maxWidth，防止出现性能问题
+## 注意
+
+-   宽度的计算过程是一个比较耗时的动作，同一页面内该组件使用次数保持在 100 个以内，如果存在性能问题，考虑先支持虚拟滚动等技术后，在使用该组件。
 
 ## 示例
 
-<code src="./demos/basic.tsx" title="基础使用"></code>
-<code src="./demos/maxWidth.tsx" title="进阶使用" description="请更改窗口大小"></code>
+<code src="./demos/basic.tsx" title="基础使用" description="请更改窗口大小"></code>
+<code src="./demos/maxWidth.tsx" title="宽度限制" ></code>
+<code src="./demos/inlineElement.tsx" title="行内元素" description="行内元素无法获得宽度，在计算时会不断向上查找，直到找到一个能够正确获取宽度的父元素，并以找到父元素宽度当作文本的可视宽度" ></code>
+<code src="./demos/flex.tsx" title="flex" description="请更改窗口大小"></code>
+<code src="./demos/multiple.tsx" title="同一容器多个 EllipsisText 组件" description="都必须传入 maxWidth"></code>
 
 ## API
 
@@ -30,8 +31,8 @@ demo:
 | value     | 显示文本内容                       | `string \| number` | -      |
 | className | 为文本内容所在节点添加自定义样式名 | `string`           | -      |
 | maxWidth  | 文本内容的最大宽度                 | `string \| number` | -      |
-| title     | 提示文字                           | `string \| number` | -      |
+| title     | 提示文字                           | `ReactNode`        | -      |
 
 :::info
-其余参数继承自 [继承 antd3.x 的 Tooltip](https://3x.ant.design/components/tooltip-cn/#header)
+其余参数继承自 [继承 antd4.x 的 Tooltip](https://4x.ant.design/components/tooltip-cn/#API)
 :::

--- a/src/ellipsisText/index.md
+++ b/src/ellipsisText/index.md
@@ -20,18 +20,19 @@ demo:
 
 <code src="./demos/basic.tsx" title="基础使用" description="请更改窗口大小"></code>
 <code src="./demos/maxWidth.tsx" title="宽度限制" ></code>
-<code src="./demos/inlineElement.tsx" title="行内元素" description="行内元素无法获得宽度，在计算时会不断向上查找，直到找到一个能够正确获取宽度的父元素，并以找到父元素宽度当作文本的可视宽度" ></code>
-<code src="./demos/flex.tsx" title="flex" description="请更改窗口大小"></code>
+<code src="./demos/inlineElement.tsx" title="在行内元素中使用" description="行内元素无法获得宽度，在计算时会不断向上查找，直到找到一个能够正确获取宽度的父元素，并以找到父元素宽度当作文本的可视宽度" ></code>
+<code src="./demos/flex.tsx" title="在 flex 中使用" description="请更改窗口大小"></code>
 <code src="./demos/multiple.tsx" title="同一容器多个 EllipsisText 组件" description="都必须传入 maxWidth"></code>
+<code src="./demos/valueType.tsx" title="支持 ReactNode" description="只支持返回的 dom 为行内元素"></code>
 
 ## API
 
-| 参数      | 说明                               | 类型               | 默认值 |
-| --------- | ---------------------------------- | ------------------ | ------ |
-| value     | 显示文本内容                       | `string \| number` | -      |
-| className | 为文本内容所在节点添加自定义样式名 | `string`           | -      |
-| maxWidth  | 文本内容的最大宽度                 | `string \| number` | -      |
-| title     | 提示文字                           | `ReactNode`        | -      |
+| 参数      | 说明                               | 类型                                                 | 默认值 |
+| --------- | ---------------------------------- | ---------------------------------------------------- | ------ |
+| value     | 显示文本内容                       | `string \| number \| ReactNode   \| () => ReactNode` | -      |
+| title     | 提示文字                           | `string \| number \| ReactNode   \| () => ReactNode` | value  |
+| className | 为文本内容所在节点添加自定义样式名 | `string`                                             | -      |
+| maxWidth  | 文本内容的最大宽度                 | `string \| number`                                   | -      |
 
 :::info
 其余参数继承自 [继承 antd4.x 的 Tooltip](https://4x.ant.design/components/tooltip-cn/#API)

--- a/src/ellipsisText/index.md
+++ b/src/ellipsisText/index.md
@@ -27,12 +27,12 @@ demo:
 
 ## API
 
-| 参数      | 说明                               | 类型                                                 | 默认值 |
-| --------- | ---------------------------------- | ---------------------------------------------------- | ------ |
-| value     | 显示文本内容                       | `string \| number \| ReactNode   \| () => ReactNode` | -      |
-| title     | 提示文字                           | `string \| number \| ReactNode   \| () => ReactNode` | value  |
-| className | 为文本内容所在节点添加自定义样式名 | `string`                                             | -      |
-| maxWidth  | 文本内容的最大宽度                 | `string \| number`                                   | -      |
+| 参数      | 说明                               | 类型                             | 默认值 |
+| --------- | ---------------------------------- | -------------------------------- | ------ |
+| value     | 显示文本内容                       | `ReactNode   \| () => ReactNode` | -      |
+| title     | 提示文字                           | `ReactNode   \| () => ReactNode` | value  |
+| className | 为文本内容所在节点添加自定义样式名 | `string`                         | -      |
+| maxWidth  | 文本内容的最大宽度                 | `string \| number`               | -      |
 
 :::info
 其余参数继承自 [继承 antd4.x 的 Tooltip](https://4x.ant.design/components/tooltip-cn/#API)

--- a/src/ellipsisText/index.tsx
+++ b/src/ellipsisText/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
+import React, { useRef, useState, useLayoutEffect, useCallback, ReactNode } from 'react';
 import { Tooltip } from 'antd';
 import { AbstractTooltipProps, RenderFunction } from 'antd/lib/tooltip';
 import classNames from 'classnames';
@@ -6,10 +6,26 @@ import Resize from '../resize';
 import './style.scss';
 
 export interface EllipsisTextProps extends AbstractTooltipProps {
-    value: string | number;
-    title?: React.ReactNode | RenderFunction;
+    /**
+     * 文本内容
+     */
+    value: string | number | ReactNode | RenderFunction;
+    /**
+     * 提示内容
+     * @default value
+     */
+    title?: string | ReactNode | RenderFunction;
+    /**
+     * 类名
+     */
     className?: string;
+    /**
+     * 可视区宽度
+     */
     maxWidth?: string | number;
+    /**
+     * antd Tooltip
+     */
     [propName: string]: any;
 }
 
@@ -20,7 +36,7 @@ export interface NewHTMLElement extends HTMLElement {
 const DEFAULT_MAX_WIDTH = 120;
 
 const EllipsisText = (props: EllipsisTextProps) => {
-    const { title, value, className, maxWidth, ...otherProps } = props;
+    const { value, title = value, className, maxWidth, ...otherProps } = props;
 
     const ellipsisRef = useRef<HTMLSpanElement>(null);
 
@@ -30,7 +46,7 @@ const EllipsisText = (props: EllipsisTextProps) => {
 
     useLayoutEffect(() => {
         onResize();
-    }, [value]);
+    }, [value, maxWidth]);
 
     /**
      * @description: 根据属性名，获取dom的属性值
@@ -193,7 +209,7 @@ const EllipsisText = (props: EllipsisTextProps) => {
                 className={classNames('dtc-ellipsis-text', className)}
                 style={style}
             >
-                {value}
+                {typeof value === 'function' ? value() : value}
             </span>
         );
     }, [width, cursor, value]);
@@ -201,12 +217,7 @@ const EllipsisText = (props: EllipsisTextProps) => {
     return (
         <Resize onResize={onResize}>
             {visible ? (
-                <Tooltip
-                    title={title || value}
-                    mouseEnterDelay={0}
-                    mouseLeaveDelay={0}
-                    {...otherProps}
-                >
+                <Tooltip title={title} mouseEnterDelay={0} mouseLeaveDelay={0} {...otherProps}>
                     {renderText()}
                 </Tooltip>
             ) : (

--- a/src/ellipsisText/index.tsx
+++ b/src/ellipsisText/index.tsx
@@ -1,7 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
 import { Tooltip } from 'antd';
-import Resize from '../resize';
 import { AbstractTooltipProps, RenderFunction } from 'antd/lib/tooltip';
+import classNames from 'classnames';
+import Resize from '../resize';
+import './style.scss';
 
 export interface EllipsisTextProps extends AbstractTooltipProps {
     value: string | number;
@@ -11,126 +13,207 @@ export interface EllipsisTextProps extends AbstractTooltipProps {
     [propName: string]: any;
 }
 
-const initialState = {
-    visible: false,
-    isEllipsis: false,
-    // eslint-disable-next-line no-void
-    actMaxWidth: void 0,
-};
-
-type State = Omit<typeof initialState, 'actMaxWidth'> & { actMaxWidth?: number };
-
 export interface NewHTMLElement extends HTMLElement {
     currentStyle?: CSSStyleDeclaration;
 }
 
 const DEFAULT_MAX_WIDTH = 120;
 
-export default class EllipsisText extends PureComponent<EllipsisTextProps, State> {
-    ellipsisRef: HTMLElement | null = null;
-    state = {
-        ...initialState,
+const EllipsisText = (props: EllipsisTextProps) => {
+    const { title, value, className, maxWidth, ...otherProps } = props;
+
+    const ellipsisRef = useRef<HTMLSpanElement>(null);
+
+    const [visible, setVisible] = useState(false);
+    const [width, setWidth] = useState<number | string>(DEFAULT_MAX_WIDTH);
+    const [cursor, setCursor] = useState('default');
+
+    useLayoutEffect(() => {
+        onResize();
+    }, [value]);
+
+    /**
+     * @description: 根据属性名，获取dom的属性值
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getStyle = (dom: NewHTMLElement, attr: string) => {
+        // Compatible width IE8
+        // @ts-ignore
+        return window.getComputedStyle(dom)[attr] || dom.currentStyle[attr];
     };
 
-    componentDidMount() {
-        this.onResize();
-    }
+    /**
+     * @description: 根据属性名，获取dom的属性值为number的属性。如： height、width。。。
+     * @param {NewHTMLElement} dom
+     * @param {string} attr
+     * @return {*}
+     */
+    const getNumTypeStyleValue = (dom: NewHTMLElement, attr: string) => {
+        return parseInt(getStyle(dom, attr));
+    };
 
-    componentDidUpdate(preProps: EllipsisTextProps) {
-        const { value } = this.props;
-        if (value !== preProps.value) {
-            this.onResize();
+    /**
+     * @description: 10 -> 10,
+     * @description: 10px -> 10,
+     * @description: 90% -> ele.width * 0.9
+     * @description: calc(100% - 32px) -> ele.width - 32
+     * @param {*} ele
+     * @param {string & number} maxWidth
+     * @return {*}
+     */
+    const transitionWidth = (ele: HTMLElement, maxWidth: string | number) => {
+        const eleWidth = getActualWidth(ele);
+
+        if (typeof maxWidth === 'number') {
+            return maxWidth > eleWidth ? eleWidth : maxWidth; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
         }
-    }
 
-    getRangeWidth = (ele: HTMLElement) => {
+        const numMatch = maxWidth.match(/^(\d+)(px)?$/);
+        if (numMatch) {
+            return +numMatch[1] > eleWidth ? eleWidth : +numMatch[1]; // 如果父元素的宽度小于传入的最大宽度，返回父元素的宽度
+        }
+
+        const percentMatch = maxWidth.match(/^(\d+)%$/);
+        if (percentMatch) {
+            return eleWidth * (parseInt(percentMatch[1]) / 100);
+        }
+
+        const relativeMatch = maxWidth.match(/^calc\(100% - (\d+)px\)$/);
+        if (relativeMatch) {
+            return eleWidth - parseInt(relativeMatch[1]);
+        }
+
+        return eleWidth;
+    };
+
+    const hideEleContent = (node: HTMLElement) => {
+        node.style.display = 'none';
+    };
+
+    const showEleContent = (node: HTMLElement) => {
+        node.style.display = 'inline-block';
+    };
+
+    /**
+     * @description: 获取能够得到宽度的最近父元素宽度。行内元素无法获得宽度，需向上查找父元素
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getContainerWidth = (ele: HTMLElement): number | string => {
+        if (!ele) return DEFAULT_MAX_WIDTH;
+
+        const { scrollWidth, parentElement } = ele;
+
+        // 如果是行内元素，获取不到宽度，则向上寻找父元素
+        if (scrollWidth === 0) {
+            return getContainerWidth(parentElement!);
+        }
+        // 如果设置了最大宽度，则直接返回宽度
+        if (maxWidth) {
+            return transitionWidth(ele, maxWidth);
+        }
+
+        hideEleContent(ellipsisRef.current!);
+
+        const availableWidth = getAvailableWidth(ele);
+
+        return availableWidth < 0 ? 0 : availableWidth;
+    };
+
+    /**
+     * @description: 获取dom元素的内容宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getRangeWidth = (ele: HTMLElement): any => {
         const range = document.createRange();
         range.selectNodeContents(ele);
         const rangeWidth = range.getBoundingClientRect().width;
+
         return rangeWidth;
     };
 
-    getStyle = (dom: NewHTMLElement, attr: any) => {
-        // Compatible width IE8
-        const stylePadding = window?.getComputedStyle(dom)[attr] || dom.currentStyle?.[attr] || '';
-
-        return parseInt(stylePadding.replace('px', ''));
+    /**
+     * @description: 获取元素不包括 padding 的宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getActualWidth = (ele: HTMLElement) => {
+        const width = ele.getBoundingClientRect().width;
+        const paddingLeft = getNumTypeStyleValue(ele, 'paddingLeft');
+        const paddingRight = getNumTypeStyleValue(ele, 'paddingRight');
+        return width - paddingLeft - paddingRight;
     };
 
-    // The nearest block parent element
-    getMaxWidth = (ele: HTMLElement): number => {
-        // The default maximum width is 120px when the element does not exist
-        if (!ele) return DEFAULT_MAX_WIDTH;
-        const { scrollWidth, offsetWidth, parentElement } = ele;
-        // If inline element, find the parent element
-        if (scrollWidth === 0) {
-            return this.getMaxWidth(parentElement!);
+    /**
+     * @description: 获取dom的可用宽度
+     * @param {HTMLElement} ele
+     * @return {*}
+     */
+    const getAvailableWidth = (ele: HTMLElement) => {
+        const width = getActualWidth(ele);
+        const contentWidth = getRangeWidth(ele);
+        const ellipsisWidth = width - contentWidth;
+        return ellipsisWidth;
+    };
+
+    /**
+     * @description: 计算父元素的宽度是否满足内容的大小
+     * @return {*}
+     */
+    const onResize = () => {
+        const ellipsisNode = ellipsisRef.current!;
+        const parentElement = ellipsisNode.parentElement!;
+        const rangeWidth = getRangeWidth(ellipsisNode);
+        const containerWidth = getContainerWidth(parentElement);
+        const visible = rangeWidth > containerWidth;
+        setVisible(visible);
+        setWidth(containerWidth);
+        const parentCursor = getStyle(parentElement, 'cursor');
+        if (parentCursor !== 'default') {
+            // 继承父元素的 hover 手势
+            setCursor(parentCursor);
+        } else {
+            // 截取文本时，则改变 hover 手势为 pointer
+            visible && setCursor('pointer');
         }
-        const ellipsisNode = this.ellipsisRef!;
-        ellipsisNode.style.display = 'none';
-        // Get the width of elements other than omitted text
-        const rangeWidth = this.getRangeWidth(ele);
-        const ellipsisWidth =
-            offsetWidth -
-            rangeWidth -
-            this.getStyle(ele, 'paddingRight') -
-            this.getStyle(ele, 'paddingLeft');
-
-        return ellipsisWidth < 0 ? 0 : ellipsisWidth;
+        showEleContent(ellipsisNode);
     };
 
-    onResize = () => {
-        const { maxWidth } = this.props;
-        // if props has maxWidth don't have to calculate the text length
-        if (maxWidth) return;
-        const ellipsisNode = this.ellipsisRef!;
-        const rangeWidth = this.getRangeWidth(ellipsisNode);
-        const ellipsisWidth = this.getMaxWidth(ellipsisNode.parentElement!);
-        ellipsisNode.style.display = 'inline-block';
-        this.setState({
-            actMaxWidth: ellipsisWidth,
-            isEllipsis: rangeWidth > (maxWidth || ellipsisWidth),
-        });
-    };
-
-    // handleVisibleChange = (visible: boolean) => {
-    //   const { isEllipsis } = this.state;
-
-    //   this.setState({
-    //     visible: visible && isEllipsis
-    //   });
-    // };
-
-    render() {
-        const { actMaxWidth, isEllipsis } = this.state;
-        const { title, value, className, maxWidth, ...other } = this.props;
-
+    const renderText = useCallback(() => {
+        const style: React.CSSProperties = {
+            maxWidth: width,
+            cursor,
+        };
         return (
-            <Resize onResize={maxWidth ? undefined : this.onResize}>
+            <span
+                ref={ellipsisRef}
+                className={classNames('dtc-ellipsis-text', className)}
+                style={style}
+            >
+                {value}
+            </span>
+        );
+    }, [width, cursor, value]);
+
+    return (
+        <Resize onResize={onResize}>
+            {visible ? (
                 <Tooltip
                     title={title || value}
-                    // visible={visible}
-                    // onVisibleChange={this.handleVisibleChange}
-                    {...other}
+                    mouseEnterDelay={0}
+                    mouseLeaveDelay={0}
+                    {...otherProps}
                 >
-                    <span
-                        ref={(ref) => (this.ellipsisRef = ref)}
-                        className={className}
-                        style={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            display: 'inline-block',
-                            verticalAlign: 'bottom',
-                            minWidth: '2em',
-                            maxWidth: maxWidth || actMaxWidth,
-                            cursor: isEllipsis ? 'pointer' : 'default',
-                        }}
-                    >
-                        {value}
-                    </span>
+                    {renderText()}
                 </Tooltip>
-            </Resize>
-        );
-    }
-}
+            ) : (
+                renderText()
+            )}
+        </Resize>
+    );
+};
+
+export default EllipsisText;

--- a/src/ellipsisText/index.tsx
+++ b/src/ellipsisText/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import Resize from '../resize';
 import './style.scss';
 
-export interface EllipsisTextProps extends AbstractTooltipProps {
+export interface IEllipsisTextProps extends AbstractTooltipProps {
     /**
      * 文本内容
      */
@@ -35,7 +35,7 @@ export interface NewHTMLElement extends HTMLElement {
 
 const DEFAULT_MAX_WIDTH = 120;
 
-const EllipsisText = (props: EllipsisTextProps) => {
+const EllipsisText = (props: IEllipsisTextProps) => {
     const { value, title = value, className, maxWidth, ...otherProps } = props;
 
     const ellipsisRef = useRef<HTMLSpanElement>(null);

--- a/src/ellipsisText/style.scss
+++ b/src/ellipsisText/style.scss
@@ -1,0 +1,7 @@
+.dtc-ellipsis-text {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+}


### PR DESCRIPTION
简介
本 PR 主要负责 ellipsisTest 组件的重构

主要变更
自动识别内容宽度，与父元素宽度比较，如果比父元素宽度大，则展示 tootip 气泡，相反则不展示 tootip 气泡
元素宽度统一使用 getBoundingClientRect ().width 获取。确保都为浮点型
如果有传入 maxWidth。则以 maxWidth 为宽，否则以计算的父元素可用区域为宽
如果父元素手势不为 default， 则继承父元素的手势。否则根据内容是否超出判断，未超出为default, 超出则为 pointer，
遗留问题
在无法拿到父元素宽度的情况下，会出现计算异常的问题。

用户侧：
需要确保父元素能够拿到宽度。

预览：
https://zaoei.github.io/dt-react-component/components/ellipsis-text