### PR TITLE
refactor(markdownRender): improve markdownRender

### DIFF
--- a/src/markdownRender/__tests__/__snapshots__/markdownRender.test.tsx.snap
+++ b/src/markdownRender/__tests__/__snapshots__/markdownRender.test.tsx.snap
@@ -1,0 +1,181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test MarkdownRender Component Should detect language by highlight 1`] = `
+<DocumentFragment>
+  <div
+    class="dtc-markdown-render-body dtc-vs-dark"
+  >
+    <pre>
+      <code>
+        hljs console.
+        <span
+          class="hljs-built_in"
+        >
+          log
+        </span>
+        (
+        <span
+          class="hljs-string"
+        >
+          'test'
+        </span>
+        );
+
+      </code>
+    </pre>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Test MarkdownRender Component Should match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="dtc-markdown-render-body dtc-vs"
+  >
+    <h1
+      id="h1"
+    >
+      h1
+    </h1>
+    
+
+    <h2
+      id="h2"
+    >
+      h2
+    </h2>
+    
+
+    <h3
+      id="h3"
+    >
+      h3
+    </h3>
+    
+
+    <ul>
+      
+
+      <li>
+        a
+      </li>
+      
+
+      <li>
+        b
+      </li>
+      
+
+      <li>
+        c
+      </li>
+      
+
+    </ul>
+    
+
+    <p>
+      <a
+        href="https://github.com/DTStack/dt-react-component"
+      >
+        url
+      </a>
+    </p>
+    
+
+    <p>
+      <strong>
+        strong1
+      </strong>
+    </p>
+    
+
+    <p>
+      <strong>
+        strong2
+      </strong>
+    </p>
+    
+
+    <p>
+      <em>
+        Italic
+      </em>
+    </p>
+    
+
+    <blockquote>
+      
+  
+      <p>
+        blockquote
+      </p>
+      
+
+    </blockquote>
+    
+
+    <p>
+      <code>
+        code block
+      </code>
+    </p>
+    
+
+    <hr />
+    
+
+    <table>
+      
+    
+      <tbody>
+        <tr>
+          
+        
+          <td>
+            Foo
+          </td>
+          
+    
+        </tr>
+        
+
+      </tbody>
+    </table>
+    
+
+    <pre>
+      <code
+        class="hljs sql language-sql"
+      >
+        <span
+          class="hljs-comment"
+        >
+          -- desc
+        </span>
+        
+
+        <span
+          class="hljs-keyword"
+        >
+          select
+        </span>
+         
+        <span
+          class="hljs-operator"
+        >
+          *
+        </span>
+         
+        <span
+          class="hljs-keyword"
+        >
+          from
+        </span>
+         employees
+
+      </code>
+    </pre>
+  </div>
+</DocumentFragment>
+`;

--- a/src/markdownRender/__tests__/markdownRender.test.tsx
+++ b/src/markdownRender/__tests__/markdownRender.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+import MarkdownRender from '..';
+
+describe('Test MarkdownRender Component', () => {
+    beforeEach(cleanup);
+    it('Should match snapshot', () => {
+        const { asFragment } = render(
+            <MarkdownRender
+                value={`
+# h1
+## h2
+### h3
+
+- a
+- b
+- c
+
+[url](https://github.com/DTStack/dt-react-component)
+
+**strong1**
+
+__strong2__
+
+_Italic_
+
+> blockquote
+
+\`code block\`
+
+---
+
+<table>
+    <tr>
+        <td>Foo</td>
+    </tr>
+</table>
+
+\`\`\`sql
+-- desc
+select * from employees
+\`\`\`
+        `}
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('Should render dark', () => {
+        const { container } = render(
+            <MarkdownRender
+                dark
+                value={`
+\`\`\`sql
+-- desc
+select * from employees
+\`\`\`
+        `}
+            />
+        );
+
+        const renderBody = container.querySelector<HTMLDivElement>('.dtc-markdown-render-body');
+
+        expect(renderBody).not.toBeNull();
+        expect(renderBody?.className).toContain('dtc-vs-dark');
+    });
+
+    it('Should detect language by highlight', () => {
+        const { asFragment } = render(
+            <MarkdownRender
+                dark
+                value={`
+\`\`\`
+console.log('test');
+\`\`\`
+        `}
+            />
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('Should render empty value', () => {
+        const { container } = render(<MarkdownRender />);
+        expect(container.querySelector('.dtc-markdown-render-body')?.innerHTML).toBe('');
+    });
+});

--- a/src/markdownRender/demos/basic.tsx
+++ b/src/markdownRender/demos/basic.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { MarkdownRender } from 'dt-react-component';
+
+export default () => {
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        fetch('https://cdn.jsdelivr.net/npm/dt-react-component@3.0.8/CHANGELOG.md', {
+            method: 'get',
+        })
+            .then((res) => res.text())
+            .then(setValue);
+    }, []);
+
+    return (
+        <div style={{ maxHeight: 200, overflow: 'auto', marginBottom: 16 }}>
+            <MarkdownRender value={value} />
+        </div>
+    );
+};

--- a/src/markdownRender/demos/dark.tsx
+++ b/src/markdownRender/demos/dark.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { MarkdownRender } from 'dt-react-component';
+
+const md = `
+以下是一段 sql 语法
+
+\`\`\`sql
+ select count(*) from a;
+-- name sqltest 
+-- type sql 
+-- create time 2022-11-09 16:13:45 
+-- desc
+
+
+-- create table employees(name string);
+insert into employees values('1111');
+
+
+select * from employees
+\`\`\`
+`;
+
+export default () => {
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        setValue(md);
+    }, []);
+
+    return (
+        <div style={{ maxHeight: 400, overflow: 'auto', marginBottom: 16 }}>
+            <MarkdownRender dark value={value} />
+        </div>
+    );
+};

--- a/src/markdownRender/demos/sql.tsx
+++ b/src/markdownRender/demos/sql.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { MarkdownRender } from 'dt-react-component';
+
+const md = `
+以下是一段 sql 语法
+
+\`\`\`sql
+ select count(*) from a;
+-- name sqltest 
+-- type sql 
+-- create time 2022-11-09 16:13:45 
+-- desc
+
+
+-- create table employees(name string);
+insert into employees values('1111');
+
+
+select * from employees
+\`\`\`
+`;
+
+export default () => {
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        setValue(md);
+    }, []);
+
+    return (
+        <div style={{ maxHeight: 400, overflow: 'auto', marginBottom: 16 }}>
+            <MarkdownRender value={value} />
+        </div>
+    );
+};

--- a/src/markdownRender/extensions/index.ts
+++ b/src/markdownRender/extensions/index.ts
@@ -1,0 +1,33 @@
+import showdown from 'showdown';
+import hljs from 'highlight.js';
+import sql from 'highlight.js/lib/languages/sql';
+import 'highlight.js/styles/default.css';
+import '../theme/vs.scss';
+import '../theme/vs-dark.scss';
+
+hljs.registerLanguage('sql', sql);
+
+export default function sqlHighlightExtension(): showdown.ShowdownExtension {
+    return {
+        type: 'output',
+        filter: function (text) {
+            return showdown.helper.replaceRecursiveRegExp(
+                text.replace(/&gt;/g, '>').replace(/&lt;/g, '<'),
+                (_: string, match: string, left: string, right: string) => {
+                    const lang = (left.match(/class=\"([^ \"]+)/) || [])[1];
+
+                    // Append hljs class
+                    const prefix = left.slice(0, 18) + 'hljs ' + left.slice(18);
+                    if (lang && hljs.getLanguage(lang)) {
+                        return prefix + hljs.highlight(match, { language: lang }).value + right;
+                    } else {
+                        return prefix + hljs.highlightAuto(match).value + right;
+                    }
+                },
+                '<pre><code\\b[^>]*>',
+                '</code></pre>',
+                'g'
+            );
+        },
+    };
+}

--- a/src/markdownRender/index.md
+++ b/src/markdownRender/index.md
@@ -1,35 +1,25 @@
 ---
-title: MarkdownRender markdown 渲染
+title: MarkdownRender 渲染
 group: 组件
 toc: content
-demo:
-    cols: 2
 ---
 
-# MarkdownRender markdown 渲染
+# MarkdownRender 渲染
 
 ## 何时使用
 
-路由未匹配上的展示页
+用于 Markdown 语法在 HTML 上展示，只负责渲染
 
 ## 示例
 
-```jsx
-import React from 'react';
-import { MarkdownRender } from 'dt-react-component';
-
-export default () => {
-    const md = `# Test
-+ 我是测试数据
-+ 我是测试数据
-### hello markdownRender`;
-    return <MarkdownRender text={md} dark={false} />;
-};
-```
+<code src="./demos/basic.tsx" compact="true" title="展示 Markdown 内容"></code>
+<code src="./demos/dark.tsx" compact="true" title="暗黑模式下"></code>
+<code src="./demos/sql.tsx" compact="true" title="SQL 语法高亮"></code>
 
 ## API
 
-| 参数 | 说明              | 类型      | 默认值 |
-| ---- | ----------------- | --------- | ------ |
-| text | markdown 文本数据 | `string`  | -      |
-| dark | 主题设置          | `boolean` | -      |
+| 参数      | 说明              | 类型      | 默认值 |
+| --------- | ----------------- | --------- | ------ |
+| value     | markdown 文本数据 | `string`  | -      |
+| dark      | 暗黑主题          | `boolean` | -      |
+| className | 类名              | `string`  | -      |

--- a/src/markdownRender/index.tsx
+++ b/src/markdownRender/index.tsx
@@ -1,63 +1,38 @@
-import React from 'react';
-
+import React, { useMemo } from 'react';
 import showdown from 'showdown';
-import hljs from 'highlight.js';
-import sql from 'highlight.js/lib/languages/sql';
-import classNames from 'classnames';
+import classnames from 'classnames';
+import sqlHighlightExtension from './extensions';
 import './style.scss';
 
-export interface MarkdownRenderProps {
-    text?: string;
+export interface IMarkdownRenderProps {
+    /**
+     * 当前渲染的值
+     */
+    value?: string;
     className?: string;
+    /**
+     * 暗黑模式
+     */
     dark?: boolean;
 }
 
-hljs.registerLanguage('sql', sql);
-showdown.extension('highlight', function () {
-    return [
-        {
-            type: 'output',
-            filter: function (text: string, _converter: any, _options: any) {
-                let textTemp = text;
-                const left = '<pre><code\\b[^>]*>';
-                const right = '</code></pre>';
-                const flags = 'g';
-                const replacement = function (wholeMatch: any, match: any, left: any, right: any) {
-                    // Append hljs class
-                    let leftTemp = left;
-                    leftTemp = leftTemp.slice(0, 18) + 'hljs ' + leftTemp.slice(18);
+export default function MarkdownRender({ value = '', className, dark }: IMarkdownRenderProps) {
+    const result = useMemo(() => {
+        const converter = new showdown.Converter({
+            extensions: [sqlHighlightExtension],
+            emoji: true,
+        });
+        return converter.makeHtml(value);
+    }, [value]);
 
-                    const lang = (leftTemp.match(/class=\"([^ \"]+)/) || [])[1];
-                    if (lang && hljs.getLanguage(lang)) {
-                        return leftTemp + hljs.highlight(lang, match).value + right;
-                    } else {
-                        return leftTemp + hljs.highlightAuto(match).value + right;
-                    }
-                };
-
-                textTemp = textTemp.replace(/&gt;/g, '>');
-                textTemp = textTemp.replace(/&lt;/g, '<');
-
-                return showdown.helper.replaceRecursiveRegExp(
-                    textTemp,
-                    replacement,
-                    left,
-                    right,
-                    flags
-                );
-            },
-        },
-    ];
-});
-showdown.setOption('optionKey', 'value');
-
-export default function MarkdownRender(props: MarkdownRenderProps) {
-    const { text, className, dark } = props;
-    const cls = classNames('dtc-markdown-render-body', dark ? 'dtc-vs-dark' : 'dtc-vs', className);
-    const converter = new showdown.Converter({
-        extensions: ['highlight'],
-        emoji: true,
-    });
-    const result = converter.makeHtml(text);
-    return <div className={cls} dangerouslySetInnerHTML={{ __html: result }} />;
+    return (
+        <div
+            className={classnames(
+                'dtc-markdown-render-body',
+                dark ? 'dtc-vs-dark' : 'dtc-vs',
+                className
+            )}
+            dangerouslySetInnerHTML={{ __html: result }}
+        />
+    );
 }


### PR DESCRIPTION
# 简介
- 重构 MarkdownRender 组件

# Changes
1. `text` -> `value`
2. 修复获取 language 失败的问题，按照之前的逻辑先 `Append hljs class`，再通过正则获取 language 会获取到 hljs，这是不符合预期的。所以要先获取 language 再 append class