### PR TITLE
refactor: switchWindow to refactor as hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,5 @@ export { default as Resize } from './resize';
 export { default as SlidePane } from './slidePane';
 export { default as SpreadSheet } from './spreadSheet';
 export { default as StatusTag } from './statusTag';
-export { default as SwitchWindow } from './switchWindow';
+export { default as useWindowSwitchListener } from './switchWindow';
 export { default as useCookieListener } from './cookies';

--- a/src/switchWindow/__tests__/switchWindow.test.tsx
+++ b/src/switchWindow/__tests__/switchWindow.test.tsx
@@ -9,15 +9,13 @@ describe('test useWindowSwitchListener hooks', () => {
     });
     test('test callBack to called', () => {
         const fn = jest.fn();
-        renderHook(() => useWindowSwitchListener({ onSwitch: fn }));
+        renderHook(() =>
+            useWindowSwitchListener(() => {
+                fn();
+            })
+        );
         window.dispatchEvent(new Event('focus'));
         expect(fn).toHaveBeenCalled();
         expect(fn).toHaveBeenCalledTimes(1);
-    });
-    test('test callBack not to called', () => {
-        const fn = jest.fn();
-        renderHook(() => useWindowSwitchListener({}));
-        window.dispatchEvent(new Event('focus'));
-        expect(fn).not.toHaveBeenCalled();
     });
 });

--- a/src/switchWindow/__tests__/switchWindow.test.tsx
+++ b/src/switchWindow/__tests__/switchWindow.test.tsx
@@ -1,0 +1,23 @@
+import useWindowSwitchListener from '../index';
+import { cleanup, renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('test useWindowSwitchListener hooks', () => {
+    afterEach(() => {
+        cleanup();
+        jest.resetAllMocks();
+    });
+    test('test callBack to called', () => {
+        const fn = jest.fn();
+        renderHook(() => useWindowSwitchListener({ onSwitch: fn }));
+        window.dispatchEvent(new Event('focus'));
+        expect(fn).toHaveBeenCalled();
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+    test('test callBack not to called', () => {
+        const fn = jest.fn();
+        renderHook(() => useWindowSwitchListener({}));
+        window.dispatchEvent(new Event('focus'));
+        expect(fn).not.toHaveBeenCalled();
+    });
+});

--- a/src/switchWindow/demos/basic.tsx
+++ b/src/switchWindow/demos/basic.tsx
@@ -7,7 +7,9 @@ export default () => {
         setMsg('window listener');
         console.log('window listener');
     };
-    useWindowSwitchListener({ onSwitch: handleSwitch });
+    useWindowSwitchListener(() => {
+        handleSwitch();
+    });
 
     return (
         <div

--- a/src/switchWindow/demos/basic.tsx
+++ b/src/switchWindow/demos/basic.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { useWindowSwitchListener } from 'dt-react-component';
+
+export default () => {
+    const [msg, setMsg] = useState('hello world');
+    const handleSwitch = () => {
+        setMsg('window listener');
+        console.log('window listener');
+    };
+    useWindowSwitchListener({ onSwitch: handleSwitch });
+
+    return (
+        <div
+            style={{
+                height: '100%',
+                width: '100%',
+            }}
+        >
+            {msg}
+        </div>
+    );
+};

--- a/src/switchWindow/index.md
+++ b/src/switchWindow/index.md
@@ -1,51 +1,20 @@
 ---
-title: SwitchWindow 窗口切换事件监听
+title: useWindowSwitchListener 监听窗口触发焦点事件
 group: 组件
 toc: content
 demo:
     cols: 2
 ---
 
-# SwitchWindow 窗口切换事件监听
+# useWindowSwitchListener 监听窗口触发焦点事件
 
 ## 何时使用
 
-窗口切换事件监听
+监听当前窗口获取焦点时，执行某个回调时使用
 
 ## 示例
 
-```jsx
-/**
- * title: "基础使用"
- */
-import React, { useState } from 'react';
-import { SwitchWindow } from 'dt-react-component';
-
-export default () => {
-    const [msg, setMsg] = useState('hello world');
-
-    return (
-        <>
-            <SwitchWindow
-                onSwitch={() => {
-                    setMsg('window listener');
-                    console.log('window listener');
-                }}
-            >
-                <div
-                    id="box"
-                    style={{
-                        height: '100%',
-                        width: '100%',
-                    }}
-                >
-                    {msg}
-                </div>
-            </SwitchWindow>
-        </>
-    );
-};
-```
+<code src='./demos/basic.tsx' title='基础使用'></code>
 
 ## API
 

--- a/src/switchWindow/index.tsx
+++ b/src/switchWindow/index.tsx
@@ -1,36 +1,25 @@
-import React from 'react';
-export interface SwitchWindowProps {
-    onSwitch?: (evt) => void;
-    style?: React.CSSProperties;
-    children?: React.ReactNode;
+import { useEffect } from 'react';
+export interface ISwitchWindowProps {
+    onSwitch?: (evt: FocusEvent) => void;
 }
-/**
- * 窗口切换事件监听，
- * 用法：
- * <SwitchWindow onSwitch={}></SwitchWindow>
- */
-class SwitchWindow extends React.Component<SwitchWindowProps, any> {
-    componentDidMount() {
-        this.initEvent();
-    }
 
-    listener = (e: any) => {
-        const { onSwitch } = this.props;
+const useWindowSwitchListener = ({ onSwitch }: ISwitchWindowProps) => {
+    useEffect(() => {
+        handleAddListener();
+        return () => {
+            handleRemoveListener();
+        };
+    }, []);
+    const listener = (e: FocusEvent) => {
         console.log('switch window is focusing!', window.location);
-        if (onSwitch) onSwitch(e);
+        onSwitch?.(e);
     };
-
-    componentWillUnmount() {
-        window.removeEventListener('focus', this.listener);
-    }
-
-    initEvent = () => {
-        window.addEventListener('focus', this.listener);
+    const handleAddListener = () => {
+        window.addEventListener('focus', listener);
     };
+    const handleRemoveListener = () => {
+        window.removeEventListener('focus', listener);
+    };
+};
 
-    render() {
-        return <React.Fragment>{this.props.children}</React.Fragment>;
-    }
-}
-
-export default SwitchWindow;
+export default useWindowSwitchListener;

--- a/src/switchWindow/index.tsx
+++ b/src/switchWindow/index.tsx
@@ -1,24 +1,24 @@
-import { useEffect } from 'react';
-export interface ISwitchWindowProps {
-    onSwitch?: (evt: FocusEvent) => void;
-}
+import { useCallback, useEffect } from 'react';
 
-const useWindowSwitchListener = ({ onSwitch }: ISwitchWindowProps) => {
+const useWindowSwitchListener = (onSwitch: (evt: FocusEvent) => void) => {
     useEffect(() => {
-        handleAddListener();
+        const eventListener = (e: FocusEvent) => listener(e);
+        handleAddListener(eventListener);
         return () => {
-            handleRemoveListener();
+            handleRemoveListener(eventListener);
         };
     }, []);
-    const listener = (e: FocusEvent) => {
-        console.log('switch window is focusing!', window.location);
-        onSwitch?.(e);
+    const listener = useCallback(
+        (e: FocusEvent) => {
+            return onSwitch(e);
+        },
+        [onSwitch]
+    );
+    const handleAddListener = (eventListener: (e: FocusEvent) => void) => {
+        window.addEventListener('focus', eventListener);
     };
-    const handleAddListener = () => {
-        window.addEventListener('focus', listener);
-    };
-    const handleRemoveListener = () => {
-        window.removeEventListener('focus', listener);
+    const handleRemoveListener = (eventListener: (e: FocusEvent) => void) => {
+        window.removeEventListener('focus', eventListener);
     };
 };
 


### PR DESCRIPTION
# SwitchWindow
监听窗口触发focus事件
# 变更
- 改写成 hooks 
- 不支持props传入children 的形式
- 用法修改： 改为 
```
useWindowSwitchListener(() => {
        handleSwitch();
});
```
- 补充单测 
- 修改docs
# 预览地址
https://shiqiwang0.github.io/dt-react-component/components/switch-window
# 涉及范围 
目前业务中没有产品使用到该组件
# changeLog
https://dtstack.yuque.com/rd-center/tqk74v/mpvba83z25nrzws2