### PR TITLE
fix: add padding for errorBoundary demos

### DIFF
--- a/src/errorBoundary/demos/basic.tsx
+++ b/src/errorBoundary/demos/basic.tsx
@@ -12,6 +12,7 @@ const ThrowError = () => {
                 flexDirection: 'column',
                 justifyContent: 'center',
                 alignItems: 'center',
+                paddingTop: 60,
             }}
         >
             <button
@@ -19,8 +20,8 @@ const ThrowError = () => {
                     border: 'none',
                     backgroundColor: '#1890ff',
                     cursor: 'pointer',
-                    height: '32px',
-                    borderRadius: '4px',
+                    height: 32,
+                    borderRadius: 4,
                 }}
                 onClick={() => setCount((count) => count + 1)}
             >

--- a/src/errorBoundary/demos/customErrorPage.tsx
+++ b/src/errorBoundary/demos/customErrorPage.tsx
@@ -12,6 +12,7 @@ const ThrowError = () => {
                 flexDirection: 'column',
                 justifyContent: 'center',
                 alignItems: 'center',
+                paddingTop: 60,
             }}
         >
             <button
@@ -19,8 +20,8 @@ const ThrowError = () => {
                     border: 'none',
                     backgroundColor: '#1890ff',
                     cursor: 'pointer',
-                    height: '32px',
-                    borderRadius: '4px',
+                    height: 32,
+                    borderRadius: 4,
                 }}
                 onClick={() => setCount((count) => count + 1)}
             >


### PR DESCRIPTION
ErrorBoundary 文档Demo样式修复
#314 
<img width="877" alt="image" src="https://user-images.githubusercontent.com/64318393/234260195-f7ad74c0-eb5d-49c2-840f-ac3ca5508941.png">
