### PR TITLE
Feat update slide pane

### DIFF
--- a/src/blockHeader/__tests__/blockHeader.test.tsx
+++ b/src/blockHeader/__tests__/blockHeader.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { SizeType } from 'dt-react-component/esm/blockHeader';
 import '@testing-library/jest-dom/extend-expect';
 
-import BlockHeader from '../index';
+import BlockHeader, { SizeType } from '../index';
 
 const props = {
     title: '标题1',

--- a/src/slidePane/__tests/__snapshots__/index.test.tsx.snap
+++ b/src/slidePane/__tests/__snapshots__/index.test.tsx.snap
@@ -1,3 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test SlidePane  snapshot match 1`] = `<DocumentFragment />`;
+exports[`test SlidePane  snapshot match 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div />
+    <div>
+      <div
+        class="dtc-slide-pane dtc-slide-pane-right dtc-slide-pane-open"
+        tabindex="-1"
+      >
+        <div
+          aria-hidden="true"
+          data-sentinel="start"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
+          tabindex="0"
+        />
+        <div
+          class="dtc-slide-pane-content-wrapper"
+          style="width: 378px;"
+        >
+          <div
+            aria-modal="true"
+            class="dtc-slide-pane-content"
+            role="dialog"
+          >
+            <img
+              alt="closeBtn"
+              class="dtc-slide-pane-icon"
+              src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAABwCAYAAAAE0LDPAAAAAXNSR0IArs4c6QAAAnlJREFUaEPtmk9IVHEQx78jufpw7ykouuEaBG6dEmrXOmRRt476VgvyEngKlNqQMu3PoSU7iCBq4CW2olNdRMRr7HasnnZb0y57WGODzUDjt/RIonbeyzfQYd51h/m8+c7395u3MOSs5Xexr4dKRLt5AhYJtbPRaNO7velo/4Bf6YhoB8B0R3vzNSLaNr8ECnBRRLTc0d583kBEAJU3J5o6HG0ZkgTs1OBATAxgqqghTIoCiPBeFABQSRggZFOxg/anC0ElYq9JlUglYhVgA9RFKhGrABugLlKJWAXYAHWRSsQqwAaoi1QiVgE2gHVRejKDUKgWQ1cvmj/XbMLfA3jA42dwVvPo7+tBd/xo8ICNzQLG7y3AskIYvz2IcEO9LwhbgcmWebGCpeUcEvEYBvrOBg8ol7cxOjaP4lYJqZEkIm2NniGeKjDZ3mQ/YPbJa7S1NiI1YntuuGeAgTx8lMHqx3XYvWdwOnHMUxW+AJufC7hzdwH1VggTt64gHLZYiC+Ayfb85QoWl3KIn+jEpeS54AHlb98xOjaHYrGEG8M2DkWaqkJ8V2CyZd86mJl7hdaWg7h5PVm14f8EMJD0zxM+ePkCuo4f+WsV/ycgm3MwMy8k0d4mp4ZtRIJusmvTxMlODNgB21T8oLlXRbK3B6cS3maDZxeJXnbudb315Wvl9AZ+XbsDpzseQ3/QA+fTRgET9wVHpvmqcNbWK6PSjEy/D9vkB+mnaLDq5D5b/L6x7+8iBbBNVolUItYDKpFKxCrABqiLVCJWATZAXaQSsQqwAeoilYhVgA1QFzESCS8wia9giS6Rma1B0TU40UU+sVVEoWXK6uugPwBjVkdxauLcgwAAAABJRU5ErkJggg=="
+            />
+            <div
+              class="dtc-slide-pane-body"
+            >
+              Hello World
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          data-sentinel="end"
+          style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
+          tabindex="0"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div />,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/slidePane/__tests/index.test.tsx
+++ b/src/slidePane/__tests/index.test.tsx
@@ -19,7 +19,7 @@ describe('test SlidePane ', () => {
         expect(dom).toBe(null);
         unmount();
         render(
-            <SlidePane visible showMask>
+            <SlidePane visible mask>
                 Hello World
             </SlidePane>
         );

--- a/src/slidePane/__tests/index.test.tsx
+++ b/src/slidePane/__tests/index.test.tsx
@@ -1,46 +1,118 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import SlidePane from '../index';
 
 describe('test SlidePane ', () => {
-    const expectValues = {
-        children: (
-            <div>
-                <h1>success</h1>
-            </div>
-        ),
-        visible: true,
-        style: { color: 'red', background: '#FF7C12' },
-    };
     test('snapshot match', () => {
-        const { asFragment } = render(
-            <SlidePane visible={expectValues.visible}>{expectValues.children}</SlidePane>
-        );
-        expect(asFragment()).toMatchSnapshot();
-    });
-    test('should render correct', () => {
-        render(
-            <SlidePane visible={expectValues.visible} style={expectValues.style}>
-                {expectValues.children}
-            </SlidePane>
-        );
-        const wrapper = document.getElementsByClassName('dtc-slide-pane');
-        expect(wrapper?.[0]).toHaveStyle(expectValues.style);
-        expect(screen.getByRole('heading')).toHaveTextContent('success');
+        const wrapper = render(<SlidePane visible>Hello World</SlidePane>);
+        expect(wrapper).toMatchSnapshot();
     });
     test('should be invisible', () => {
-        const { container } = render(
-            <SlidePane visible={false}>{expectValues.children}</SlidePane>
-        );
+        const { container } = render(<SlidePane visible={false}>Hello World</SlidePane>);
         expect(container).not.toHaveClass();
+    });
+    test('should render mask correct ', () => {
+        const { unmount } = render(<SlidePane visible>Hello World</SlidePane>);
+        const dom = document.querySelector('.dtc-slide-pane-mask');
+        expect(dom).toBe(null);
+        unmount();
+        render(
+            <SlidePane visible showMask>
+                Hello World
+            </SlidePane>
+        );
+        const domMask = document.querySelector('.dtc-slide-pane-mask');
+        expect(domMask).not.toBe(null);
+    });
+    test('should render width correct', () => {
+        render(
+            <SlidePane visible width={640}>
+                Hello World
+            </SlidePane>
+        );
+        expect(document.querySelector('.dtc-slide-pane-content-wrapper')).toHaveStyle({
+            width: '640px',
+        });
+    });
+    test('should render className/style correct', () => {
+        const { unmount } = render(
+            <SlidePane
+                visible
+                rootClassName="root-className"
+                bodyClassName="body-className"
+                rootStyle={{ color: 'red' }}
+                bodyStyle={{ backgroundColor: 'forestgreen' }}
+            >
+                Hello World
+            </SlidePane>
+        );
+        expect(document.querySelector('.dtc-slide-pane')).toHaveClass('root-className');
+        expect(document.querySelector('.dtc-slide-pane-body')).toHaveClass('body-className');
+        expect(document.querySelector('.dtc-slide-pane')).toHaveStyle({ color: 'red' });
+        expect(document.querySelector('.dtc-slide-pane-body')).toHaveStyle({
+            backgroundColor: 'forestgreen',
+        });
+        unmount();
+    });
+    test('should render tab correct', () => {
+        const { getByText, unmount } = render(
+            <SlidePane
+                visible
+                width={640}
+                tabs={[
+                    { key: '1', title: 'tab1' },
+                    { key: '2', title: 'tab2' },
+                ]}
+            >
+                {(key) => {
+                    switch (key) {
+                        case '1':
+                            return <div>基本信息</div>;
+                        case '2':
+                            return <div>变更记录</div>;
+                        default:
+                            break;
+                    }
+                }}
+            </SlidePane>
+        );
+        expect(document.querySelector('.dtc-slide-pane-tabs')).not.toBe(null);
+        expect(getByText('tab1')).toBeTruthy();
+        expect(getByText('基本信息')).toBeTruthy();
+        unmount();
+
+        const { getByText: getByText1 } = render(
+            <SlidePane
+                visible
+                width={640}
+                tabs={[
+                    { key: '1', title: 'tab1' },
+                    { key: '2', title: 'tab2' },
+                ]}
+                activeKey="2"
+            >
+                {(key) => {
+                    switch (key) {
+                        case '1':
+                            return <div>基本信息</div>;
+                        case '2':
+                            return <div>变更记录</div>;
+                        default:
+                            break;
+                    }
+                }}
+            </SlidePane>
+        );
+        expect(getByText1('变更记录')).toBeTruthy();
+        expect(getByText1('tab2').parentNode).toHaveClass('ant-tabs-tab-active');
     });
     test('should callback to be called', () => {
         const fn = jest.fn();
         const { getByRole } = render(
             <SlidePane visible onClose={fn}>
-                {expectValues.children}
+                Hello World
             </SlidePane>
         );
         const oImg = getByRole('img');

--- a/src/slidePane/demos/basic.tsx
+++ b/src/slidePane/demos/basic.tsx
@@ -20,10 +20,6 @@ export default () => {
             </Button>
             <SlidePane
                 visible={visible}
-                rootStyle={{
-                    minHeight: '600px',
-                    height: '100%',
-                }}
                 width={`${width}%`}
                 onClose={() => setVisible(false)}
                 title="title"

--- a/src/slidePane/demos/basic_mask.tsx
+++ b/src/slidePane/demos/basic_mask.tsx
@@ -27,6 +27,7 @@ export default () => {
                 width={`${width}%`}
                 onClose={() => setVisible(false)}
                 title="title"
+                showRenderButton={false}
             >
                 <div>hello world</div>
             </SlidePane>

--- a/src/slidePane/demos/basic_mask.tsx
+++ b/src/slidePane/demos/basic_mask.tsx
@@ -27,7 +27,7 @@ export default () => {
                 width={`${width}%`}
                 onClose={() => setVisible(false)}
                 title="title"
-                showRenderButton={false}
+                showMask
             >
                 <div>hello world</div>
             </SlidePane>

--- a/src/slidePane/demos/basic_mask.tsx
+++ b/src/slidePane/demos/basic_mask.tsx
@@ -27,7 +27,7 @@ export default () => {
                 width={`${width}%`}
                 onClose={() => setVisible(false)}
                 title="title"
-                showMask
+                mask
             >
                 <div>hello world</div>
             </SlidePane>

--- a/src/slidePane/demos/customTitle.tsx
+++ b/src/slidePane/demos/customTitle.tsx
@@ -1,32 +1,29 @@
 import React, { useState } from 'react';
-import { Button, Slider } from 'antd';
+import { Button } from 'antd';
 import { SlidePane } from 'dt-react-component';
 
 export default () => {
     const [visible, setVisible] = useState(false);
-    const [width, setWidth] = useState(80);
 
     return (
         <>
-            <Slider
-                defaultValue={width}
-                min={10}
-                max={100}
-                onChange={(value: number) => setWidth(value)}
-            />
-            <span>width:{width}%</span>
-            <Button style={{ margin: '10px' }} onClick={() => setVisible((v) => !v)}>
-                click me
-            </Button>
+            <Button onClick={() => setVisible(true)}>打开</Button>
             <SlidePane
                 visible={visible}
                 rootStyle={{
                     minHeight: '600px',
                     height: '100%',
                 }}
-                width={`${width}%`}
                 onClose={() => setVisible(false)}
-                title="title"
+                title={
+                    <div>
+                        <div>增信方式</div>
+                        <div>
+                            <span>创建时间： xxxx</span>
+                            <span>更新时间： xxxx</span>
+                        </div>
+                    </div>
+                }
             >
                 <div>hello world</div>
             </SlidePane>

--- a/src/slidePane/demos/tabs.tsx
+++ b/src/slidePane/demos/tabs.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Button } from 'antd';
+import { SlidePane } from 'dt-react-component';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setVisible(true)}>打开</Button>
+            <SlidePane
+                visible={visible}
+                onClose={() => setVisible(false)}
+                title={'Title'}
+                tabs={[
+                    {
+                        key: 'basicInfo',
+                        title: '基本信息',
+                    },
+                    {
+                        key: 'changelog',
+                        title: '变更记录',
+                    },
+                ]}
+            >
+                {(key: string) => {
+                    switch (key) {
+                        case 'basicInfo':
+                            return <div>基本信息</div>;
+                        case 'changelog':
+                            return <div>变更记录</div>;
+                        default:
+                            break;
+                    }
+                }}
+            </SlidePane>
+        </>
+    );
+};

--- a/src/slidePane/demos/tabs.tsx
+++ b/src/slidePane/demos/tabs.tsx
@@ -22,6 +22,7 @@ export default () => {
                         title: '变更记录',
                     },
                 ]}
+                activeKey="changelog"
             >
                 {(key: string) => {
                     switch (key) {

--- a/src/slidePane/demos/tabs.tsx
+++ b/src/slidePane/demos/tabs.tsx
@@ -12,19 +12,21 @@ export default () => {
                 visible={visible}
                 onClose={() => setVisible(false)}
                 title={'Title'}
-                tabs={[
-                    {
-                        key: 'basicInfo',
-                        title: '基本信息',
-                    },
-                    {
-                        key: 'changelog',
-                        title: '变更记录',
-                    },
-                ]}
+                tabs={
+                    [
+                        {
+                            key: 'basicInfo',
+                            title: '基本信息',
+                        },
+                        {
+                            key: 'changelog',
+                            title: '变更记录',
+                        },
+                    ] as const
+                }
                 activeKey="changelog"
             >
-                {(key: string) => {
+                {(key) => {
                     switch (key) {
                         case 'basicInfo':
                             return <div>基本信息</div>;

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -22,10 +22,17 @@ demo:
 
 ## API
 
-| 参数      | 说明                   | 类型            | 默认值 |
-| --------- | ---------------------- | --------------- | ------ |
-| visible   | SlidePanel 是否可见    | `boolean`       | -      |
-| className | 右侧面板外层容器的类名 | `string`        | -      |
-| style     | 右侧面板外层容器的样式 | `CSSProperties` | -      |
-| bodyStyle | 右侧面板内部容器的样式 | `CSSProperties` | -      |
-| onClose   | 关闭回调               | `function`      | -      |
+| 参数          | 说明                           | 类型                                                  | 默认值 |
+| ------------- | ------------------------------ | ----------------------------------------------------- | ------ |
+| visible       | SlidePanel 是否可见            | `boolean`                                             | -      |
+| title         | 右侧面板的 title               | `React.ReactNode`                                     | -      |
+| showMask      | 是否展示遮罩层                 | `boolean`                                             | false  |
+| width         | 右侧面板的宽度                 | `number \| string`                                    | -      |
+| children      | 右侧面板展示内容               | `(key: string) => React.ReactNode \| React.ReactNode` | -      |
+| tabs          | 右侧面板的内容的 Tabs          | `{ key: string; title: React.ReactNode }[]`           | -      |
+| activeKeys    | 右侧面板的内容的 Tabs 的选中项 | `string`                                              | -      |
+| rootClassName | 右侧面板外层容器的类名         | `string`                                              | -      |
+| bodyClassName | 内容容器的类名                 | `string`                                              | -      |
+| rootStyle     | 右侧面板内部容器的样式         | `CSSProperties`                                       | -      |
+| bodyStyle     | 内容容器的样式                 | `CSSProperties`                                       | -      |
+| onClose       | 关闭回调                       | `function`                                            | -      |

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -16,6 +16,8 @@ demo:
 ## 示例
 
 <code src="./demos/basic.tsx" title="基础使用"></code>
+<code src="./demos/basic_mask.tsx" title="基础 mask 使用"></code>
+<code src="./demos/customTitle.tsx" title="自定义 Title"></code>
 
 ## API
 

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -18,6 +18,7 @@ demo:
 <code src="./demos/basic.tsx" title="基础使用"></code>
 <code src="./demos/basic_mask.tsx" title="基础 mask 使用"></code>
 <code src="./demos/customTitle.tsx" title="自定义 Title"></code>
+<code src="./demos/tabs.tsx" title="展示 tabs"></code>
 
 ## API
 

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -26,7 +26,7 @@ demo:
 | ------------- | ------------------------------ | ----------------------------------------------------- | ------ |
 | visible       | SlidePanel 是否可见            | `boolean`                                             | -      |
 | title         | 右侧面板的 title               | `React.ReactNode`                                     | -      |
-| showMask      | 是否展示遮罩层                 | `boolean`                                             | false  |
+| mask          | 是否展示遮罩层                 | `boolean`                                             | false  |
 | width         | 右侧面板的宽度                 | `number \| string`                                    | -      |
 | children      | 右侧面板展示内容               | `(key: string) => React.ReactNode \| React.ReactNode` | -      |
 | tabs          | 右侧面板的内容的 Tabs          | `{ key: string; title: React.ReactNode }[]`           | -      |

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -6,7 +6,16 @@ import RcDrawer from 'rc-drawer';
 import motionProps from './motion';
 import './style.scss';
 
-type TabsSlidePane = {
+interface Tab {
+    readonly key: string;
+    readonly title: React.ReactNode;
+}
+
+type readOnlyTab = readonly Tab[];
+
+type TabKey<T extends readOnlyTab> = T[number]['key'];
+
+type TabsSlidePane<T extends readOnlyTab> = {
     visible: boolean;
     rootClassName?: string;
     bodyClassName?: string;
@@ -15,9 +24,9 @@ type TabsSlidePane = {
     mask?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
-    tabs?: { key: string; title: React.ReactNode }[];
-    activeKey?: string;
-    children?: (key: string) => React.ReactNode;
+    tabs?: T;
+    activeKey?: TabKey<T>;
+    children?: (key: TabKey<T>) => React.ReactNode;
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 };
 
@@ -34,13 +43,13 @@ type NormalSlidePane = {
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 };
 
-function isFunction(props: any): props is TabsSlidePane {
+function isFunction(props: any): props is TabsSlidePane<Tab[]> {
     return typeof props.children === 'function';
 }
 
-export type SlidePaneProps = TabsSlidePane | NormalSlidePane;
+export type SlidePaneProps<T extends readOnlyTab> = TabsSlidePane<T> | NormalSlidePane;
 
-const SlidePane = (props: SlidePaneProps) => {
+const SlidePane = <T extends readOnlyTab>(props: SlidePaneProps<T>) => {
     const slidePrefixCls = 'dtc-slide-pane';
 
     const {

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, KeyboardEvent, MouseEvent, useEffect, useState } 
 import { Tabs } from 'antd';
 import RcDrawer from 'rc-drawer';
 
+import motionProps from './motion';
 import './style.scss';
 
 export interface ISlidePaneProps {
@@ -57,6 +58,7 @@ const SlidePane = ({
             onClose={onClose}
             rootStyle={rootStyle}
             width={width}
+            {...motionProps}
         >
             {showRenderButton && renderButton()}
             <div className={`${slidePrefixCls}-header`}>{title}</div>

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -6,13 +6,13 @@ import RcDrawer from 'rc-drawer';
 import motionProps from './motion';
 import './style.scss';
 
-type propWithTabs = {
+type TabsSlidePane = {
     visible: boolean;
     rootClassName?: string;
     bodyClassName?: string;
     width?: number | string;
     title?: React.ReactNode;
-    showMask?: boolean;
+    mask?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
     tabs?: { key: string; title: React.ReactNode }[];
@@ -21,24 +21,24 @@ type propWithTabs = {
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 };
 
-type propWithNoTabs = {
+type NormalSlidePane = {
     visible: boolean;
     rootClassName?: string;
     bodyClassName?: string;
     width?: number | string;
     title?: React.ReactNode;
-    showMask?: boolean;
+    mask?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
     children?: React.ReactNode;
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 };
 
-function isFunction(props: any): props is propWithTabs {
+function isFunction(props: any): props is TabsSlidePane {
     return typeof props.children === 'function';
 }
 
-export type SlidePaneProps = propWithTabs | propWithNoTabs;
+export type SlidePaneProps = TabsSlidePane | NormalSlidePane;
 
 const SlidePane = (props: SlidePaneProps) => {
     const slidePrefixCls = 'dtc-slide-pane';
@@ -47,7 +47,7 @@ const SlidePane = (props: SlidePaneProps) => {
         visible,
         rootClassName,
         bodyClassName,
-        showMask = false,
+        mask = false,
         rootStyle,
         bodyStyle,
         title,
@@ -78,14 +78,14 @@ const SlidePane = (props: SlidePaneProps) => {
             open={visible}
             placement="right"
             prefixCls={slidePrefixCls}
-            mask={showMask}
+            mask={mask}
             onClose={onClose}
             rootStyle={rootStyle}
             width={width}
             rootClassName={rootClassName}
             {...motionProps}
         >
-            {!showMask && renderButton()}
+            {!mask && renderButton()}
             {title && <div className={`${slidePrefixCls}-header`}>{title}</div>}
             {isFunction(props) && (
                 <Tabs

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -1,37 +1,30 @@
 import React, { CSSProperties, KeyboardEvent, MouseEvent, PropsWithChildren } from 'react';
-import classNames from 'classnames';
-import { assign } from 'lodash';
 import RcDrawer from 'rc-drawer';
 
 import './style.scss';
 
 export interface ISlidePaneProps {
     visible: boolean;
-    className?: string;
-    style?: CSSProperties;
+    wrapperClassName?: string;
+    width?: number | string;
+    title?: React.ReactNode;
+    showRenderButton?: boolean;
+    rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 }
 const SlidePane = ({
     visible,
-    className,
-    style,
+    wrapperClassName,
+    showRenderButton = true,
+    rootStyle,
     bodyStyle,
+    title,
     children,
+    width,
     onClose,
 }: PropsWithChildren<ISlidePaneProps>) => {
     const slidePrefixCls = 'dtc-slide-pane';
-    let rootStyle: CSSProperties = {
-        top: 0,
-        right: 0,
-        transform: visible ? undefined : 'translate3d(150%, 0, 0)',
-    };
-    const classes = classNames(className);
-
-    if (!visible) {
-        rootStyle['pointerEvents'] = 'none';
-    }
-    if (style) rootStyle = assign(rootStyle, style);
 
     const renderButton = () => {
         return (
@@ -46,17 +39,17 @@ const SlidePane = ({
 
     return (
         <RcDrawer
-            prefixCls={slidePrefixCls}
-            rootClassName={classes}
-            width="100%"
-            onClose={onClose}
             open={visible}
-            mask={false}
-            rootStyle={rootStyle}
             placement="right"
+            prefixCls={slidePrefixCls}
+            mask={!showRenderButton}
+            onClose={onClose}
+            rootStyle={rootStyle}
+            width={width}
         >
-            {renderButton()}
-            <div className={`${slidePrefixCls}-content`} style={bodyStyle}>
+            {showRenderButton && renderButton()}
+            <div className={`${slidePrefixCls}-header`}>{title}</div>
+            <div className={`${wrapperClassName} ${slidePrefixCls}-body`} style={bodyStyle}>
                 {children}
             </div>
         </RcDrawer>

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -12,10 +12,11 @@ type propWithTabs = {
     bodyClassName?: string;
     width?: number | string;
     title?: React.ReactNode;
-    showRenderButton?: boolean;
+    showMask?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
     tabs?: { key: string; title: React.ReactNode }[];
+    activeKey?: string;
     children?: (key: string) => React.ReactNode;
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
 };
@@ -26,7 +27,7 @@ type propWithNoTabs = {
     bodyClassName?: string;
     width?: number | string;
     title?: React.ReactNode;
-    showRenderButton?: boolean;
+    showMask?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
     children?: React.ReactNode;
@@ -46,7 +47,7 @@ const SlidePane = (props: SlidePaneProps) => {
         visible,
         rootClassName,
         bodyClassName,
-        showRenderButton = true,
+        showMask = false,
         rootStyle,
         bodyStyle,
         title,
@@ -58,7 +59,7 @@ const SlidePane = (props: SlidePaneProps) => {
     const [tabKey, setTabKey] = useState('');
 
     useEffect(() => {
-        visible && isFunction(props) && setTabKey(props.tabs?.[0]?.key || '');
+        visible && isFunction(props) && setTabKey(props.activeKey || props.tabs?.[0]?.key || '');
     }, [visible]);
 
     const renderButton = () => {
@@ -77,14 +78,14 @@ const SlidePane = (props: SlidePaneProps) => {
             open={visible}
             placement="right"
             prefixCls={slidePrefixCls}
-            mask={!showRenderButton}
+            mask={showMask}
             onClose={onClose}
             rootStyle={rootStyle}
             width={width}
             rootClassName={rootClassName}
             {...motionProps}
         >
-            {showRenderButton && renderButton()}
+            {!showMask && renderButton()}
             {title && <div className={`${slidePrefixCls}-header`}>{title}</div>}
             {isFunction(props) && (
                 <Tabs

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, KeyboardEvent, MouseEvent, PropsWithChildren } from 'react';
+import React, { CSSProperties, KeyboardEvent, MouseEvent, useEffect, useState } from 'react';
+import { Tabs } from 'antd';
 import RcDrawer from 'rc-drawer';
 
 import './style.scss';
@@ -11,8 +12,11 @@ export interface ISlidePaneProps {
     showRenderButton?: boolean;
     rootStyle?: CSSProperties;
     bodyStyle?: CSSProperties;
+    tabs?: { key: string; title: React.ReactNode }[];
     onClose?: (e: MouseEvent | KeyboardEvent) => void;
+    children?: React.ReactNode | ((key: string) => React.ReactNode);
 }
+
 const SlidePane = ({
     visible,
     wrapperClassName,
@@ -22,9 +26,16 @@ const SlidePane = ({
     title,
     children,
     width,
+    tabs = [],
     onClose,
-}: PropsWithChildren<ISlidePaneProps>) => {
+}: ISlidePaneProps) => {
     const slidePrefixCls = 'dtc-slide-pane';
+
+    const [tabKey, setTabKey] = useState('');
+
+    useEffect(() => {
+        visible && setTabKey(tabs?.[0]?.key);
+    }, [visible]);
 
     const renderButton = () => {
         return (
@@ -49,8 +60,20 @@ const SlidePane = ({
         >
             {showRenderButton && renderButton()}
             <div className={`${slidePrefixCls}-header`}>{title}</div>
-            <div className={`${wrapperClassName} ${slidePrefixCls}-body`} style={bodyStyle}>
-                {children}
+            {!!tabs.length && (
+                <Tabs
+                    destroyInactiveTabPane
+                    activeKey={tabKey}
+                    onChange={setTabKey}
+                    className={`${slidePrefixCls}-tabs`}
+                >
+                    {tabs.map((tab) => (
+                        <Tabs.TabPane tab={tab.title} key={tab.key} />
+                    ))}
+                </Tabs>
+            )}
+            <div className={`${wrapperClassName ?? ''} ${slidePrefixCls}-body`} style={bodyStyle}>
+                {tabs.length ? children?.(tabKey) : children}
             </div>
         </RcDrawer>
     );

--- a/src/slidePane/motion.ts
+++ b/src/slidePane/motion.ts
@@ -1,0 +1,19 @@
+import type { DrawerProps } from 'rc-drawer';
+
+export const maskMotion: DrawerProps['maskMotion'] = {
+    motionAppear: true,
+    motionName: 'mask-motion',
+    onAppearEnd: console.warn,
+};
+
+export const motion: DrawerProps['motion'] = (placement) => ({
+    motionAppear: true,
+    motionName: `panel-motion-${placement}`,
+});
+
+const motionProps: Partial<DrawerProps> = {
+    maskMotion,
+    motion,
+};
+
+export default motionProps;

--- a/src/slidePane/style.scss
+++ b/src/slidePane/style.scss
@@ -6,38 +6,40 @@ $prefix: "dtc-slide-pane";
     left: 0;
     right: 0;
     position: fixed;
-    z-index: 1050;
+    z-index: 999;
     pointer-events: none;
-    .#{$prefix}-mask {
+    &-mask {
         top: 0;
         bottom: 0;
         left: 0;
         right: 0;
         position: absolute;
-        z-index: 1050;
+        z-index: 999;
         background: rgba(0, 0, 0, 0.5);
         pointer-events: auto;
     }
-    .#{$prefix}-content-wrapper {
+    &-content-wrapper {
         position: absolute;
-        z-index: 1050;
+        z-index: 999;
         overflow: hidden;
         top: 0;
         right: 0;
         bottom: 0;
         box-shadow: -10px 0 20px 0 rgba(61, 68, 110, 0.1);
+        &-hidden {
+            display: none;
+        }
     }
-    .#{$prefix}-content-wrapper-hidden {
-        display: none;
-    }
-    .#{$prefix}-content {
+    &-content {
+        display: flex;
+        flex-direction: column;
         width: 100%;
         height: 100%;
         overflow: auto;
         background: #FFF;
         pointer-events: auto;
     }
-    .#{$prefix}-header {
+    &-header {
         padding: 16px;
         background-color: #F9F9FA;
         color: #3D446E;
@@ -45,20 +47,25 @@ $prefix: "dtc-slide-pane";
         font-size: 14px;
         line-height: 22px;
     }
-    .#{$prefix}-tabs {
+    &-tabs {
+        &.ant-tabs {
+            height: auto;
+            .ant-tabs-nav {
+                margin-bottom: 0;
+            }
+        }
         .ant-tabs-nav-wrap {
             background: #F9F9FA;
             padding-left: 16px;
             border-bottom: 1px solid #EBECF0;
         }
-        .ant-tabs-nav {
-            margin-bottom: 0;
-        }
     }
-    .#{$prefix}-body {
+    &-body {
+        flex: 1;
+        min-height: 0;
         padding: 16px;
     }
-    .#{$prefix}-icon {
+    &-icon {
         width: 12px;
         height: 56px;
         position: absolute;

--- a/src/slidePane/style.scss
+++ b/src/slidePane/style.scss
@@ -68,3 +68,81 @@ $prefix: "dtc-slide-pane";
         cursor: pointer;
     }
 }
+
+$duration: 0.3s;
+
+.mask-motion {
+    &-enter,
+    &-appear,
+    &-leave {
+        &-active {
+            transition: all $duration;
+        }
+    }
+    &-enter,
+    &-appear {
+        opacity: 0;
+        &-active {
+            opacity: 1;
+        }
+    }
+    &-leave {
+        opacity: 1;
+        &-active {
+            opacity: 0;
+        }
+    }
+}
+
+.panel-motion {
+    &-left {
+        &-enter,
+        &-appear,
+        &-leave {
+            &-start {
+                transition: none !important;
+            }
+            &-active {
+                transition: all $duration;
+            }
+        }
+        &-enter,
+        &-appear {
+            transform: translateX(-100%);
+            &-active {
+                transform: translateX(0);
+            }
+        }
+        &-leave {
+            transform: translateX(0);
+            &-active {
+                transform: translateX(-100%) !important;
+            }
+        }
+    }
+    &-right {
+        &-enter,
+        &-appear,
+        &-leave {
+            &-start {
+                transition: none !important;
+            }
+            &-active {
+                transition: all $duration;
+            }
+        }
+        &-enter,
+        &-appear {
+            transform: translateX(100%);
+            &-active {
+                transform: translateX(0);
+            }
+        }
+        &-leave {
+            transform: translateX(0);
+            &-active {
+                transform: translateX(100%) !important;
+            }
+        }
+    }
+}

--- a/src/slidePane/style.scss
+++ b/src/slidePane/style.scss
@@ -45,6 +45,16 @@ $prefix: "dtc-slide-pane";
         font-size: 14px;
         line-height: 22px;
     }
+    .#{$prefix}-tabs {
+        .ant-tabs-nav-wrap {
+            background: #F9F9FA;
+            padding-left: 16px;
+            border-bottom: 1px solid #EBECF0;
+        }
+        .ant-tabs-nav {
+            margin-bottom: 0;
+        }
+    }
     .#{$prefix}-body {
         padding: 16px;
     }

--- a/src/slidePane/style.scss
+++ b/src/slidePane/style.scss
@@ -1,18 +1,52 @@
 $prefix: "dtc-slide-pane";
 
 .#{$prefix} {
-    background: #FFF;
-    box-shadow: -10px 0 20px 0 rgba(61, 68, 110, 0.1);
-    display: inline-block;
+    top: 64px;
+    bottom: 0;
+    left: 0;
+    right: 0;
     position: fixed;
-    transition: transform 0.3s ease-in;
-    z-index: 99;
+    z-index: 1050;
+    pointer-events: none;
+    .#{$prefix}-mask {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        position: absolute;
+        z-index: 1050;
+        background: rgba(0, 0, 0, 0.5);
+        pointer-events: auto;
+    }
     .#{$prefix}-content-wrapper {
-        height: 100%;
+        position: absolute;
+        z-index: 1050;
+        overflow: hidden;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        box-shadow: -10px 0 20px 0 rgba(61, 68, 110, 0.1);
+    }
+    .#{$prefix}-content-wrapper-hidden {
+        display: none;
     }
     .#{$prefix}-content {
-        position: relative;
+        width: 100%;
         height: 100%;
+        overflow: auto;
+        background: #FFF;
+        pointer-events: auto;
+    }
+    .#{$prefix}-header {
+        padding: 16px;
+        background-color: #F9F9FA;
+        color: #3D446E;
+        font-weight: 500;
+        font-size: 14px;
+        line-height: 22px;
+    }
+    .#{$prefix}-body {
+        padding: 16px;
     }
     .#{$prefix}-icon {
         width: 12px;


### PR DESCRIPTION
#381 #383 

和 UI 确认过，UI 5.0 有两种弹窗面板。
1. 没有 mask 的，需要通过弹窗上的关闭按钮关闭，能够做数据切换的
2. 有 mask 的，和 antd 的 Drawer 类似

更改点
1. 之前的 SlidePane 只拥有第一种弹窗，本次重构将第二种弹窗也添加上了。
2. SlidePane 只是做了一个弹窗的功能，但是内部实现的 UI 都需要自己写。没写一个弹窗，header 的样式均需要重写，因此添加了 header 部分的样式，仅需要传入 title 即可
3. 新版的 SlidePane 支持传入 tabs，也是 UI 5.0 常见的形式，SlidePane 将 Tabs 相关的样式也完成了。

具体例子，请查看[SlidePane](
https://luckyfbb.github.io/dt-react-component/components/slide-pane)