### PR TITLE
feat: import highlight core only

### DIFF
--- a/src/markdownRender/extensions/index.ts
+++ b/src/markdownRender/extensions/index.ts
@@ -1,10 +1,13 @@
-import hljs from 'highlight.js/lib/core';
+import type * as Hljs from 'highlight.js';
+import hljsCore from 'highlight.js/lib/core';
 import sql from 'highlight.js/lib/languages/sql';
 import showdown from 'showdown';
 
 import 'highlight.js/styles/default.css';
 import '../theme/vs.scss';
 import '../theme/vs-dark.scss';
+
+const hljs = hljsCore as typeof Hljs;
 
 hljs.registerLanguage('sql', sql);
 

--- a/src/markdownRender/extensions/index.ts
+++ b/src/markdownRender/extensions/index.ts
@@ -1,4 +1,4 @@
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/core';
 import sql from 'highlight.js/lib/languages/sql';
 import showdown from 'showdown';
 


### PR DESCRIPTION
## 主要变更
在 `MarkdownRender` 的 extensions 中仅引入 highlight.js/core 而不是全量引入。

+ 参考文档
https://github.com/highlightjs/highlight.js/tree/10.5.0#es6-modules

## 当前问题
打包结果中包含大量不需要的内容
![image](https://github.com/DTStack/dt-react-component/assets/58289241/522a9f92-c7a3-45cb-a9fe-7c58ee129a9a)
