### PR TITLE
fix: upgrade SpreadSheet component for can be bind with ref

### DIFF
--- a/src/spreadSheet/index.tsx
+++ b/src/spreadSheet/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import type { HotTableProps } from '@handsontable/react';
 import { HotTable } from '@handsontable/react';
 import classNames from 'classnames';
@@ -25,144 +25,143 @@ export interface ISpreadSheetProps {
         /** 字段类型 */
         type: string;
     }>;
+    ref?: any;
 }
 
-const SpreadSheet: React.FC<ISpreadSheetProps> = ({
-    data,
-    columns = [],
-    className,
-    options,
-    columnTypes = [],
-}) => {
-    const tableRef = useRef<any>(null);
-    const copyUtils = new CopyUtils();
-    const _timer = useRef<NodeJS.Timeout>();
-    const { showCopyWithHeader, ...restProps } = options || {};
+const SpreadSheet: React.FC<ISpreadSheetProps> = forwardRef(
+    ({ data, columns = [], className, options, columnTypes = [] }, ref) => {
+        const tableRef = useRef<any>(null);
+        const copyUtils = new CopyUtils();
+        const _timer = useRef<NodeJS.Timeout>();
+        const { showCopyWithHeader, ...restProps } = options || {};
+        useImperativeHandle(ref, () => ({
+            tableRef,
+        }));
+        useEffect(() => {
+            if (tableRef.current) {
+                removeRenderClock();
+                _timer.current = setTimeout(() => {
+                    tableRef.current.hotInstance.render();
+                }, 100);
+            }
+            return () => {
+                removeRenderClock();
+            };
+        }, [data, columns]);
 
-    useEffect(() => {
-        if (tableRef.current) {
-            removeRenderClock();
-            _timer.current = setTimeout(() => {
-                tableRef.current.hotInstance.render();
-            }, 100);
-        }
-        return () => {
-            removeRenderClock();
+        const removeRenderClock = () => {
+            clearTimeout(_timer.current);
         };
-    }, [data, columns]);
 
-    const removeRenderClock = () => {
-        clearTimeout(_timer.current);
-    };
-
-    const getData = () => {
-        let showData = data;
-        if (!showData?.length) {
-            const emptyArr = new Array(columns.length).fill('', 0, columns.length);
-            emptyArr[0] = '暂无数据';
-            showData = [emptyArr];
-        }
-        return showData;
-    };
-
-    const getMergeCells = () => {
-        if (!data?.length) {
-            return [{ row: 0, col: 0, rowspan: 1, colspan: columns.length }];
-        }
-    };
-
-    const getCell = () => {
-        if (!data || !data.length) {
-            return [{ row: 0, col: 0, className: 'htCenter htMiddle' }];
-        }
-    };
-
-    const beforeCopy = (arr: any[]) => {
-        /**
-         * 去除格式化
-         */
-        const value = arr
-            .map((row: any[]) => {
-                return row.join('\t');
-            })
-            .join('\n');
-        copyUtils.copy(value);
-        return false;
-    };
-
-    const getContextMenu = () => {
-        const items: Record<string, { name: string; callback: Function }> = {
-            copy: {
-                name: '复制',
-                callback: function (this: any, _key: any) {
-                    const indexArr = this.getSelected();
-                    // eslint-disable-next-line prefer-spread
-                    const copyDataArr = this.getData.apply(this, indexArr[0]);
-                    beforeCopy(copyDataArr);
-                },
-            },
+        const getData = () => {
+            let showData = data;
+            if (!showData?.length) {
+                const emptyArr = new Array(columns.length).fill('', 0, columns.length);
+                emptyArr[0] = '暂无数据';
+                showData = [emptyArr];
+            }
+            return showData;
         };
-        if (showCopyWithHeader) {
-            const copyWithHeaderItem = {
-                name: '复制值以及列名',
-                callback: function (this: any, _key: any, selection: any) {
-                    const indexArr = this.getSelected();
-                    // eslint-disable-next-line prefer-spread
-                    let copyDataArr = this.getData.apply(this, indexArr[0]);
-                    const columnStart = selection?.[0]?.start?.col;
-                    const columnEnd = selection?.[0]?.end?.col;
-                    let columnArr;
-                    if (columnStart !== undefined && columnEnd !== undefined) {
-                        columnArr = columns.slice(columnStart, columnEnd + 1);
-                    }
-                    if (columnArr) {
-                        copyDataArr = [columnArr, ...copyDataArr];
-                    }
-                    beforeCopy(copyDataArr);
+
+        const getMergeCells = () => {
+            if (!data?.length) {
+                return [{ row: 0, col: 0, rowspan: 1, colspan: columns.length }];
+            }
+        };
+
+        const getCell = () => {
+            if (!data || !data.length) {
+                return [{ row: 0, col: 0, className: 'htCenter htMiddle' }];
+            }
+        };
+
+        const beforeCopy = (arr: any[]) => {
+            /**
+             * 去除格式化
+             */
+            const value = arr
+                .map((row: any[]) => {
+                    return row.join('\t');
+                })
+                .join('\n');
+            copyUtils.copy(value);
+            return false;
+        };
+
+        const getContextMenu = () => {
+            const items: Record<string, { name: string; callback: Function }> = {
+                copy: {
+                    name: '复制',
+                    callback: function (this: any, _key: any) {
+                        const indexArr = this.getSelected();
+                        // eslint-disable-next-line prefer-spread
+                        const copyDataArr = this.getData.apply(this, indexArr[0]);
+                        beforeCopy(copyDataArr);
+                    },
                 },
             };
-            // 目前版本不支持 copy_with_column_headers 暂时用 cut 代替，以达到与copy类似的表现
-            items['cut'] = copyWithHeaderItem;
-        }
-        return {
-            items,
-        } as any;
-    };
+            if (showCopyWithHeader) {
+                const copyWithHeaderItem = {
+                    name: '复制值以及列名',
+                    callback: function (this: any, _key: any, selection: any) {
+                        const indexArr = this.getSelected();
+                        // eslint-disable-next-line prefer-spread
+                        let copyDataArr = this.getData.apply(this, indexArr[0]);
+                        const columnStart = selection?.[0]?.start?.col;
+                        const columnEnd = selection?.[0]?.end?.col;
+                        let columnArr;
+                        if (columnStart !== undefined && columnEnd !== undefined) {
+                            columnArr = columns.slice(columnStart, columnEnd + 1);
+                        }
+                        if (columnArr) {
+                            copyDataArr = [columnArr, ...copyDataArr];
+                        }
+                        beforeCopy(copyDataArr);
+                    },
+                };
+                // 目前版本不支持 copy_with_column_headers 暂时用 cut 代替，以达到与copy类似的表现
+                items['cut'] = copyWithHeaderItem;
+            }
+            return {
+                items,
+            } as any;
+        };
 
-    return (
-        <HotTable
-            ref={tableRef}
-            className={classNames('dtc-handsontable-no-border', className)}
-            language="zh-CN"
-            // 空数组情况，不显示colHeaders，否则colHeaders默认会按照 A、B...显示
-            // 具体可见 https://handsontable.com/docs/7.1.1/Options.html#colHeaders
-            colHeaders={(index) => {
-                if (!columns?.length) return false;
-                // handsontable 不支持 renderCustomHeader，所以只能用 html string 实现 tooltip
-                const fieldTypeStr = columnTypes?.[index as number]?.type;
-                const title = fieldTypeStr
-                    ? `${columns?.[index as number]}: ${fieldTypeStr}`
-                    : columns?.[index as number];
-                return `<span title="${title}">${title}</span>`;
-            }}
-            data={getData()}
-            mergeCells={getMergeCells()}
-            cell={getCell()}
-            readOnly
-            rowHeaders // 数字行号
-            fillHandle={false} // 拖动复制单元格
-            manualRowResize // 拉伸功能
-            manualColumnResize // 拉伸功能
-            autoColumnSize
-            colWidths={200}
-            beforeCopy={beforeCopy}
-            beforeCut={() => false}
-            columnHeaderHeight={25}
-            contextMenu={getContextMenu()}
-            stretchH="all" // 填充空白区域
-            {...restProps}
-        />
-    );
-};
+        return (
+            <HotTable
+                ref={tableRef}
+                className={classNames('dtc-handsontable-no-border', className)}
+                language="zh-CN"
+                // 空数组情况，不显示colHeaders，否则colHeaders默认会按照 A、B...显示
+                // 具体可见 https://handsontable.com/docs/7.1.1/Options.html#colHeaders
+                colHeaders={(index) => {
+                    if (!columns?.length) return false;
+                    // handsontable 不支持 renderCustomHeader，所以只能用 html string 实现 tooltip
+                    const fieldTypeStr = columnTypes?.[index as number]?.type;
+                    const title = fieldTypeStr
+                        ? `${columns?.[index as number]}: ${fieldTypeStr}`
+                        : columns?.[index as number];
+                    return `<span title="${title}">${title}</span>`;
+                }}
+                data={getData()}
+                mergeCells={getMergeCells()}
+                cell={getCell()}
+                readOnly
+                rowHeaders // 数字行号
+                fillHandle={false} // 拖动复制单元格
+                manualRowResize // 拉伸功能
+                manualColumnResize // 拉伸功能
+                autoColumnSize
+                colWidths={200}
+                beforeCopy={beforeCopy}
+                beforeCut={() => false}
+                columnHeaderHeight={25}
+                contextMenu={getContextMenu()}
+                stretchH="all" // 填充空白区域
+                {...restProps}
+            />
+        );
+    }
+);
 
 export default SpreadSheet;


### PR DESCRIPTION
In the past, spreadsheet is a class component which can be bind with ref directly.But it's changed to a function coponent after upgraded to v4, so what using way of ref won't work.This commit is to upgrade this function component so that ref works as same as past.

--------------------------------------------------

以前的Speadsheet是一个类组件，可以直接与ref绑定。但是升级到v4后，它变成了函数组件，所以之前使用ref的方式不起作用。本次提交是升级这个函数组件，以便 ref 的工作方式与过去相同。