### PR TITLE
feat(filterrules): add FilterRules

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "@types/jest": "^29.2.3",
         "@types/lodash": "^4.14.191",
         "@types/react": "^18.0.0",
+        "@types/shortid": "^0.0.31",
         "@types/showdown": "^1.9.0",
         "@types/testing-library__jest-dom": "^5.14.5",
         "@umijs/lint": "^4.0.0",
@@ -123,6 +124,7 @@
         "mxgraph": "^4.2.2",
         "rc-drawer": "~5.1.0",
         "rc-virtual-list": "^3.4.13",
+        "shortid": "^2.2.16",
         "showdown": "^1.9.0",
         "standard-version": "^9.5.0",
         "use-clippy": "^1.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ specifiers:
   '@types/jest': ^29.2.3
   '@types/lodash': ^4.14.191
   '@types/react': ^18.0.0
+  '@types/shortid': ^0.0.31
   '@types/showdown': ^1.9.0
   '@types/testing-library__jest-dom': ^5.14.5
   '@umijs/lint': ^4.0.0
@@ -50,6 +51,7 @@ specifiers:
   react: ^18.0.0
   react-dom: ^18.0.0
   react-test-renderer: ^18.2.0
+  shortid: ^2.2.16
   showdown: ^1.9.0
   standard-version: ^9.5.0
   stylelint: ^14.9.1
@@ -69,6 +71,7 @@ dependencies:
   mxgraph: registry.npmmirror.com/mxgraph/4.2.2
   rc-drawer: registry.npmmirror.com/rc-drawer/5.1.0_react-dom@18.2.0+react@18.2.0
   rc-virtual-list: registry.npmmirror.com/rc-virtual-list/3.11.2_react-dom@18.2.0+react@18.2.0
+  shortid: 2.2.16
   showdown: registry.npmmirror.com/showdown/1.9.1
   standard-version: registry.npmmirror.com/standard-version/9.5.0
   use-clippy: registry.npmmirror.com/use-clippy/1.0.9_react@18.2.0
@@ -85,6 +88,7 @@ devDependencies:
   '@types/jest': registry.npmmirror.com/@types/jest/29.5.5
   '@types/lodash': registry.npmmirror.com/@types/lodash/4.14.199
   '@types/react': registry.npmmirror.com/@types/react/18.2.25
+  '@types/shortid': 0.0.31
   '@types/showdown': registry.npmmirror.com/@types/showdown/1.9.4
   '@types/testing-library__jest-dom': registry.npmmirror.com/@types/testing-library__jest-dom/5.14.9
   '@umijs/lint': registry.npmmirror.com/@umijs/lint/4.0.83_b81480e39899616f14bb855c30ede14b
@@ -123,10 +127,14 @@ packages:
       chalk: 2.4.2
     dev: false
 
+  /@babel/helper-string-parser/7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier/7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/highlight/7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -136,6 +144,15 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
+
+  /@babel/types/7.23.0:
+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
 
   /@commitlint/load/17.7.2:
     resolution: {integrity: sha512-XA7WTnsjHZ4YH6ZYsrnxgLdXzriwMMq+utZUET6spbOEEIPBCDLdOQXS26P+v3TTO4hUHOEhzUquaBv3jbBixw==}
@@ -668,6 +685,10 @@ packages:
   /@types/normalize-package-data/2.4.2:
     resolution: {integrity: sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==}
     dev: false
+
+  /@types/shortid/0.0.31:
+    resolution: {integrity: sha512-Ftfjb0YCx3ZKqOicoX/UsbuC5kpxqCN7k41rs1JYPQoe+sUsLhugfb3ow0MJ/pt4aPNlX5X9o084HSoVteoNmA==}
+    dev: true
 
   /@umijs/es-module-parser-darwin-arm64/0.0.7:
     resolution: {integrity: sha512-1QeNupekuVYVvL4UHyCRq4ISP2PNk4rDd9UOPONW+KpqTyP9p7RfgGpwB0VLPaFSu2ADtm0XZyIaYEGPY6zuDw==}
@@ -1574,6 +1595,15 @@ packages:
     dev: false
     optional: true
 
+  /nanoid/2.1.11:
+    resolution: {integrity: sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==}
+
+  /nanoid/3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /needle/3.2.0:
     resolution: {integrity: sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==}
     engines: {node: '>= 4.4.x'}
@@ -1583,6 +1613,8 @@ packages:
       debug: registry.npmmirror.com/debug/3.2.7
       iconv-lite: registry.npmmirror.com/iconv-lite/0.6.3
       sax: registry.npmmirror.com/sax/1.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
     optional: true
 
@@ -1835,6 +1867,12 @@ packages:
       lru-cache: 6.0.0
     dev: false
 
+  /shortid/2.2.16:
+    resolution: {integrity: sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      nanoid: 2.1.11
+
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -1977,6 +2015,11 @@ packages:
     dependencies:
       readable-stream: 3.6.2
     dev: false
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
+    dev: true
 
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -2433,7 +2476,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': link:registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   registry.npmmirror.com/@babel/plugin-syntax-async-generators/7.8.4:
@@ -4581,7 +4624,7 @@ packages:
     version: 7.20.2
     dependencies:
       '@babel/parser': registry.npmmirror.com/@babel/parser/7.23.0
-      '@babel/types': registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
       '@types/babel__generator': registry.npmmirror.com/@types/babel__generator/7.6.5
       '@types/babel__template': registry.npmmirror.com/@types/babel__template/7.4.2
       '@types/babel__traverse': registry.npmmirror.com/@types/babel__traverse/7.20.2
@@ -4592,7 +4635,7 @@ packages:
     name: '@types/babel__generator'
     version: 7.6.5
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   registry.npmmirror.com/@types/babel__template/7.4.2:
@@ -4601,7 +4644,7 @@ packages:
     version: 7.4.2
     dependencies:
       '@babel/parser': registry.npmmirror.com/@babel/parser/7.23.0
-      '@babel/types': registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   registry.npmmirror.com/@types/babel__traverse/7.20.2:
@@ -4609,7 +4652,7 @@ packages:
     name: '@types/babel__traverse'
     version: 7.20.2
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   registry.npmmirror.com/@types/debug/4.1.9:
@@ -5484,6 +5527,11 @@ packages:
     transitivePeerDependencies:
       - eslint
       - jest
+      - postcss-html
+      - postcss-jsx
+      - postcss-less
+      - postcss-markdown
+      - postcss-scss
       - styled-components
       - stylelint
       - supports-color
@@ -6375,6 +6423,8 @@ packages:
     dependencies:
       follow-redirects: registry.npmmirror.com/follow-redirects/1.5.10
       is-buffer: registry.npmmirror.com/is-buffer/2.0.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/axobject-query/2.2.0:
@@ -6461,7 +6511,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': registry.npmmirror.com/@babel/template/7.22.15
-      '@babel/types': registry.npmmirror.com/@babel/types/7.23.0
+      '@babel/types': 7.23.0
       '@types/babel__core': registry.npmmirror.com/@types/babel__core/7.20.2
       '@types/babel__traverse': registry.npmmirror.com/@types/babel__traverse/7.20.2
     dev: true
@@ -6941,7 +6991,7 @@ packages:
       mississippi: registry.npmmirror.com/mississippi/2.0.0
       mkdirp: registry.npmmirror.com/mkdirp/0.5.6
       move-concurrently: registry.npmmirror.com/move-concurrently/1.0.1
-      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1
+      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1_bluebird@3.7.2
       rimraf: registry.npmmirror.com/rimraf/2.7.1
       ssri: registry.npmmirror.com/ssri/5.3.0
       unique-filename: registry.npmmirror.com/unique-filename/1.1.1
@@ -6961,7 +7011,7 @@ packages:
       mississippi: registry.npmmirror.com/mississippi/1.3.1
       mkdirp: registry.npmmirror.com/mkdirp/0.5.6
       move-concurrently: registry.npmmirror.com/move-concurrently/1.0.1
-      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1
+      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1_bluebird@3.7.2
       rimraf: registry.npmmirror.com/rimraf/2.7.1
       ssri: registry.npmmirror.com/ssri/4.1.6
       unique-filename: registry.npmmirror.com/unique-filename/1.1.1
@@ -7372,8 +7422,10 @@ packages:
       open: registry.npmmirror.com/open/6.4.0
       ora: registry.npmmirror.com/ora/1.4.0
       pacote: registry.npmmirror.com/pacote/2.7.38
-      shortid: registry.npmmirror.com/shortid/2.2.16
+      shortid: 2.2.16
       update-notifier: registry.npmmirror.com/update-notifier/2.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/collect-v8-coverage/1.0.2:
@@ -8397,6 +8449,11 @@ packages:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz}
     name: debug
     version: 2.6.9
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: registry.npmmirror.com/ms/2.0.0
     dev: true
@@ -8405,6 +8462,11 @@ packages:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/debug/-/debug-3.1.0.tgz}
     name: debug
     version: 3.1.0
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: registry.npmmirror.com/ms/2.0.0
     dev: true
@@ -8413,6 +8475,11 @@ packages:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz}
     name: debug
     version: 3.2.7
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: registry.npmmirror.com/ms/2.1.3
     dev: true
@@ -8989,6 +9056,11 @@ packages:
       - eslint
       - jest
       - postcss
+      - postcss-html
+      - postcss-jsx
+      - postcss-less
+      - postcss-markdown
+      - postcss-scss
       - prettier
       - rollup
       - sockjs-client
@@ -9459,7 +9531,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: registry.npmmirror.com/eslint/8.22.0
-      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import/2.26.0_eslint@8.22.0
+      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import/2.26.0_53a80fa66eac2a32b769435a79ca645c
       eslint-plugin-n: registry.npmmirror.com/eslint-plugin-n/15.2.3_eslint@8.22.0
       eslint-plugin-promise: registry.npmmirror.com/eslint-plugin-promise/6.0.0_eslint@8.22.0
     dev: true
@@ -9472,22 +9544,40 @@ packages:
       debug: registry.npmmirror.com/debug/3.2.7
       is-core-module: registry.npmmirror.com/is-core-module/2.13.0
       resolve: registry.npmmirror.com/resolve/1.22.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  registry.npmmirror.com/eslint-module-utils/2.8.0_eslint@8.22.0:
+  registry.npmmirror.com/eslint-module-utils/2.8.0_1ca149ef333496942ce26f17f9c23af5:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz}
     id: registry.npmmirror.com/eslint-module-utils/2.8.0
     name: eslint-module-utils
     version: 2.8.0
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
     peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
       eslint:
         optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser/5.30.0_eslint@8.22.0+typescript@4.5.5
       debug: registry.npmmirror.com/debug/3.2.7
       eslint: registry.npmmirror.com/eslint/8.22.0
+      eslint-import-resolver-node: registry.npmmirror.com/eslint-import-resolver-node/0.3.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/eslint-plugin-dt-react/0.0.6:
@@ -9516,22 +9606,27 @@ packages:
       regexpp: registry.npmmirror.com/regexpp/3.2.0
     dev: true
 
-  registry.npmmirror.com/eslint-plugin-import/2.26.0_eslint@8.22.0:
+  registry.npmmirror.com/eslint-plugin-import/2.26.0_53a80fa66eac2a32b769435a79ca645c:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz}
     id: registry.npmmirror.com/eslint-plugin-import/2.26.0
     name: eslint-plugin-import
     version: 2.26.0
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser/5.30.0_eslint@8.22.0+typescript@4.5.5
       array-includes: registry.npmmirror.com/array-includes/3.1.7
       array.prototype.flat: registry.npmmirror.com/array.prototype.flat/1.3.2
       debug: registry.npmmirror.com/debug/2.6.9
       doctrine: registry.npmmirror.com/doctrine/2.1.0
       eslint: registry.npmmirror.com/eslint/8.22.0
       eslint-import-resolver-node: registry.npmmirror.com/eslint-import-resolver-node/0.3.9
-      eslint-module-utils: registry.npmmirror.com/eslint-module-utils/2.8.0_eslint@8.22.0
+      eslint-module-utils: registry.npmmirror.com/eslint-module-utils/2.8.0_1ca149ef333496942ce26f17f9c23af5
       has: registry.npmmirror.com/has/1.0.4
       is-core-module: registry.npmmirror.com/is-core-module/2.13.0
       is-glob: registry.npmmirror.com/is-glob/4.0.3
@@ -9539,6 +9634,10 @@ packages:
       object.values: registry.npmmirror.com/object.values/1.1.7
       resolve: registry.npmmirror.com/resolve/1.22.6
       tsconfig-paths: registry.npmmirror.com/tsconfig-paths/3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   registry.npmmirror.com/eslint-plugin-jest/26.5.3_12fbd9707179006eed94e87e25bb73bd:
@@ -10528,6 +10627,8 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       debug: registry.npmmirror.com/debug/3.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/for-each/0.3.3:
@@ -10704,7 +10805,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: registry.npmmirror.com/at-least-node/1.0.0
-      graceful-fs: registry.npmmirror.com/graceful-fs/4.2.11
+      graceful-fs: 4.2.11
       jsonfile: registry.npmmirror.com/jsonfile/6.1.0
       universalify: registry.npmmirror.com/universalify/2.0.0
     dev: true
@@ -11731,6 +11832,8 @@ packages:
     dependencies:
       agent-base: registry.npmmirror.com/agent-base/4.3.0
       debug: registry.npmmirror.com/debug/3.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/http-proxy-agent/5.0.0:
@@ -11760,6 +11863,8 @@ packages:
     dependencies:
       agent-base: registry.npmmirror.com/agent-base/4.3.0
       debug: registry.npmmirror.com/debug/3.2.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/https-proxy-agent/5.0.1:
@@ -13537,7 +13642,7 @@ packages:
       eslint-config-prettier: registry.npmmirror.com/eslint-config-prettier/8.5.0_eslint@8.22.0
       eslint-config-standard: registry.npmmirror.com/eslint-config-standard/17.0.0_7ac7ba0c849a16475149cf009583350b
       eslint-plugin-dt-react: registry.npmmirror.com/eslint-plugin-dt-react/0.0.6
-      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import/2.26.0_eslint@8.22.0
+      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import/2.26.0_53a80fa66eac2a32b769435a79ca645c
       eslint-plugin-jest: registry.npmmirror.com/eslint-plugin-jest/26.5.3_12fbd9707179006eed94e87e25bb73bd
       eslint-plugin-jsx-a11y: registry.npmmirror.com/eslint-plugin-jsx-a11y/6.6.0_eslint@8.22.0
       eslint-plugin-n: registry.npmmirror.com/eslint-plugin-n/15.2.3_eslint@8.22.0
@@ -13556,6 +13661,8 @@ packages:
       stylelint-order: registry.npmmirror.com/stylelint-order/5.0.0_stylelint@14.11.0
       stylelint-scss: registry.npmmirror.com/stylelint-scss/4.3.0_stylelint@14.11.0
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - jest
       - supports-color
       - typescript
@@ -13622,6 +13729,8 @@ packages:
       mime: 1.6.0
       needle: 3.2.0
       source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/leven/3.1.0:
@@ -14045,6 +14154,8 @@ packages:
       promise-retry: registry.npmmirror.com/promise-retry/1.1.1
       socks-proxy-agent: registry.npmmirror.com/socks-proxy-agent/3.0.1
       ssri: registry.npmmirror.com/ssri/5.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/makeerror/1.0.12:
@@ -14942,12 +15053,6 @@ packages:
     deprecated: Package no longer supported. Use at your own risk
     dev: false
 
-  registry.npmmirror.com/nanoid/2.1.11:
-    resolution: {integrity: sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/nanoid/-/nanoid-2.1.11.tgz}
-    name: nanoid
-    version: 2.1.11
-    dev: true
-
   registry.npmmirror.com/nanoid/3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/nanoid/-/nanoid-3.3.6.tgz}
     name: nanoid
@@ -15551,7 +15656,7 @@ packages:
       npm-package-arg: registry.npmmirror.com/npm-package-arg/5.1.2
       npm-pick-manifest: registry.npmmirror.com/npm-pick-manifest/1.0.4
       osenv: registry.npmmirror.com/osenv/0.1.5
-      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1
+      promise-inflight: registry.npmmirror.com/promise-inflight/1.0.1_bluebird@3.7.2
       promise-retry: registry.npmmirror.com/promise-retry/1.1.1
       protoduck: registry.npmmirror.com/protoduck/4.0.0
       safe-buffer: registry.npmmirror.com/safe-buffer/5.2.1
@@ -15561,6 +15666,8 @@ packages:
       tar-stream: registry.npmmirror.com/tar-stream/1.6.2
       unique-filename: registry.npmmirror.com/unique-filename/1.1.1
       which: registry.npmmirror.com/which/1.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/pako/1.0.11:
@@ -16851,6 +16958,22 @@ packages:
     version: 0.36.2
     peerDependencies:
       postcss: '>=5.0.0'
+      postcss-html: '*'
+      postcss-jsx: '*'
+      postcss-less: '*'
+      postcss-markdown: '*'
+      postcss-scss: '*'
+    peerDependenciesMeta:
+      postcss-html:
+        optional: true
+      postcss-jsx:
+        optional: true
+      postcss-less:
+        optional: true
+      postcss-markdown:
+        optional: true
+      postcss-scss:
+        optional: true
     dependencies:
       postcss: registry.npmmirror.com/postcss/8.4.31
     dev: true
@@ -16867,7 +16990,7 @@ packages:
     version: 8.4.14
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: registry.npmmirror.com/nanoid/3.3.6
+      nanoid: 3.3.6
       picocolors: registry.npmmirror.com/picocolors/1.0.0
       source-map-js: registry.npmmirror.com/source-map-js/1.0.2
     dev: true
@@ -17047,10 +17170,18 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
-  registry.npmmirror.com/promise-inflight/1.0.1:
+  registry.npmmirror.com/promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/promise-inflight/-/promise-inflight-1.0.1.tgz}
+    id: registry.npmmirror.com/promise-inflight/1.0.1
     name: promise-inflight
     version: 1.0.1
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: registry.npmmirror.com/bluebird/3.7.2
     dev: true
 
   registry.npmmirror.com/promise-retry/1.1.1:
@@ -19110,15 +19241,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/shortid/2.2.16:
-    resolution: {integrity: sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/shortid/-/shortid-2.2.16.tgz}
-    name: shortid
-    version: 2.2.16
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dependencies:
-      nanoid: registry.npmmirror.com/nanoid/2.1.11
-    dev: true
-
   registry.npmmirror.com/showdown/1.9.1:
     resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/showdown/-/showdown-1.9.1.tgz}
     name: showdown
@@ -20688,6 +20810,11 @@ packages:
       - eslint
       - jest
       - postcss
+      - postcss-html
+      - postcss-jsx
+      - postcss-less
+      - postcss-markdown
+      - postcss-scss
       - prettier
       - react
       - react-dom

--- a/src/filterRules/__tests__/__snapshots__/filterRules.test.tsx.snap
+++ b/src/filterRules/__tests__/__snapshots__/filterRules.test.tsx.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterRules should support FilterRules success render 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="ruleController"
+      >
+        <div
+          class="ruleController__item"
+        >
+          <div
+            class="ruleController__item--component"
+          >
+            <input
+              class="ant-input"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="ruleController__item--operation"
+          >
+            <span
+              aria-label="plus-circle"
+              class="anticon anticon-plus-circle icon"
+              role="img"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="plus-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M696 480H544V328c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v152H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h152v152c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V544h152c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8z"
+                />
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                />
+              </svg>
+            </span>
+            <span
+              aria-label="minus-circle"
+              class="anticon anticon-minus-circle icon"
+              role="img"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="minus-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M696 480H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8z"
+                />
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="ruleController"
+    >
+      <div
+        class="ruleController__item"
+      >
+        <div
+          class="ruleController__item--component"
+        >
+          <input
+            class="ant-input"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ruleController__item--operation"
+        >
+          <span
+            aria-label="plus-circle"
+            class="anticon anticon-plus-circle icon"
+            role="img"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M696 480H544V328c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v152H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h152v152c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V544h152c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8z"
+              />
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+            </svg>
+          </span>
+          <span
+            aria-label="minus-circle"
+            class="anticon anticon-minus-circle icon"
+            role="img"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="minus-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M696 480H328c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h368c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8z"
+              />
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/filterRules/__tests__/filterRules.test.tsx
+++ b/src/filterRules/__tests__/filterRules.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { Input } from 'antd';
 import '@testing-library/jest-dom/extend-expect';
 
-import { INIT_DATA, INIT_ROW_VALUES, IRow } from '../demos/basic';
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from '../demos/constants';
 import FilterRules, { IComponentProps } from '..';
 
 const MyInput = ({ rowValues: { input }, rowKey, onChange }: IComponentProps<IRow>) => (

--- a/src/filterRules/__tests__/filterRules.test.tsx
+++ b/src/filterRules/__tests__/filterRules.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Input } from 'antd';
+import '@testing-library/jest-dom/extend-expect';
+
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from '../demos/basic';
+import FilterRules, { IComponentProps } from '..';
+
+const MyInput = ({ rowValues: { input }, rowKey, onChange }: IComponentProps<IRow>) => (
+    <Input value={input} onChange={(e) => onChange?.(rowKey, { input: e.target.value })} />
+);
+
+describe('FilterRules', () => {
+    test('should support FilterRules success render', () => {
+        const wrapper = render(
+            <FilterRules<IRow>
+                component={(props) => <MyInput {...props} />}
+                value={INIT_DATA}
+                initValues={INIT_ROW_VALUES}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('calls onChange on add condition button click', () => {
+        const handleChange = jest.fn();
+        const { container } = render(
+            <FilterRules<IRow>
+                component={(props) => <MyInput {...props} />}
+                value={INIT_DATA}
+                onChange={handleChange}
+                initValues={INIT_ROW_VALUES}
+            />
+        );
+        fireEvent.click(container.querySelector('.anticon-plus-circle') as Element);
+        expect(handleChange).toHaveBeenCalled();
+    });
+
+    test('calls onChange on delete condition button click when notEmpty is false', () => {
+        const handleChange = jest.fn();
+        const { container } = render(
+            <FilterRules<IRow>
+                component={(props) => <MyInput {...props} />}
+                value={INIT_DATA}
+                onChange={handleChange}
+                initValues={INIT_ROW_VALUES}
+                notEmpty={{ data: false }}
+            />
+        );
+        fireEvent.click(container.querySelector('.anticon-minus-circle') as Element);
+        expect(handleChange).toHaveBeenCalled();
+    });
+
+    test('not calls onChange on delete condition button click when notEmpty is true', () => {
+        const handleChange = jest.fn();
+        const { container } = render(
+            <FilterRules<IRow>
+                component={(props) => <MyInput {...props} />}
+                value={INIT_DATA}
+                onChange={handleChange}
+                initValues={INIT_ROW_VALUES}
+            />
+        );
+        fireEvent.click(container.querySelector('.anticon-minus-circle') as Element);
+        expect(handleChange).not.toHaveBeenCalled();
+    });
+});

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Button, Input } from 'antd';
+import { FilterRules } from 'dt-react-component';
+import { IComponentProps } from 'dt-react-component/filterRules';
 import shortid from 'shortid';
-
-import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -31,6 +31,7 @@ export default () => {
                 component={(props) => <MyInput {...props} />}
                 value={data}
                 onChange={(value: any) => setData(value)}
+                initRowValues={INIT_ROW_VALUES}
             />
 
             <Button onClick={() => console.log(data)}>控制台查看数据</Button>

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Button, Input } from 'antd';
+import shortid from 'shortid';
+
+import { FilterRules } from '..';
+
+const INIT_ROW_VALUES = {
+    input: '',
+};
+
+const INIT_DATA = {
+    key: shortid(),
+    level: 0,
+    formValues: {
+        ...INIT_ROW_VALUES,
+    },
+};
+
+type IRow = typeof INIT_ROW_VALUES;
+
+const MyInput = ({
+    input,
+    rowKey,
+    onChange,
+}: {
+    input?: string;
+    rowKey?: string;
+    onChange?: (key: string, values: Partial<IRow>) => void;
+}) => <Input value={input} onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })} />;
+
+export default () => {
+    const [data, setData] = useState(INIT_DATA);
+
+    return (
+        <>
+            <FilterRules<IRow>
+                component={<MyInput />}
+                value={data}
+                onChange={(value: any) => setData(value)}
+            />
+
+            <Button onClick={() => console.log(data)}>控制台查看数据</Button>
+        </>
+    );
+};

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -4,11 +4,11 @@ import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
 import shortid from 'shortid';
 
-const INIT_ROW_VALUES = {
+export const INIT_ROW_VALUES = {
     input: '',
 };
 
-const INIT_DATA = {
+export const INIT_DATA = {
     key: shortid(),
     level: 0,
     rowValues: {
@@ -16,7 +16,7 @@ const INIT_DATA = {
     },
 };
 
-type IRow = typeof INIT_ROW_VALUES;
+export type IRow = typeof INIT_ROW_VALUES;
 
 const MyInput = ({ rowValues: { input }, rowKey, onChange }: IComponentProps<IRow>) => (
     <Input value={input} onChange={(e) => onChange?.(rowKey, { input: e.target.value })} />

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Input } from 'antd';
 import shortid from 'shortid';
 
-import { FilterRules } from '..';
+import FilterRules from '..';
 
 const INIT_ROW_VALUES = {
     input: '',

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Input } from 'antd';
 import shortid from 'shortid';
 
-import FilterRules from '..';
+import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -11,22 +11,16 @@ const INIT_ROW_VALUES = {
 const INIT_DATA = {
     key: shortid(),
     level: 0,
-    formValues: {
+    rowValues: {
         ...INIT_ROW_VALUES,
     },
 };
 
 type IRow = typeof INIT_ROW_VALUES;
 
-const MyInput = ({
-    input,
-    rowKey,
-    onChange,
-}: {
-    input?: string;
-    rowKey?: string;
-    onChange?: (key: string, values: Partial<IRow>) => void;
-}) => <Input value={input} onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })} />;
+const MyInput = ({ rowValues: { input }, key, onChange }: IComponentProps<IRow>) => (
+    <Input value={input} onChange={(e) => onChange?.(key ?? '', { input: e.target.value })} />
+);
 
 export default () => {
     const [data, setData] = useState(INIT_DATA);
@@ -34,7 +28,7 @@ export default () => {
     return (
         <>
             <FilterRules<IRow>
-                component={<MyInput />}
+                component={(props) => <MyInput {...props} />}
                 value={data}
                 onChange={(value: any) => setData(value)}
             />

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -2,21 +2,8 @@ import React, { useState } from 'react';
 import { Button, Input } from 'antd';
 import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
-import shortid from 'shortid';
 
-export const INIT_ROW_VALUES = {
-    input: '',
-};
-
-export const INIT_DATA = {
-    key: shortid(),
-    level: 0,
-    rowValues: {
-        ...INIT_ROW_VALUES,
-    },
-};
-
-export type IRow = typeof INIT_ROW_VALUES;
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from './constants';
 
 const MyInput = ({ rowValues: { input }, rowKey, onChange }: IComponentProps<IRow>) => (
     <Input value={input} onChange={(e) => onChange?.(rowKey, { input: e.target.value })} />

--- a/src/filterRules/demos/basic.tsx
+++ b/src/filterRules/demos/basic.tsx
@@ -18,8 +18,8 @@ const INIT_DATA = {
 
 type IRow = typeof INIT_ROW_VALUES;
 
-const MyInput = ({ rowValues: { input }, key, onChange }: IComponentProps<IRow>) => (
-    <Input value={input} onChange={(e) => onChange?.(key ?? '', { input: e.target.value })} />
+const MyInput = ({ rowValues: { input }, rowKey, onChange }: IComponentProps<IRow>) => (
+    <Input value={input} onChange={(e) => onChange?.(rowKey, { input: e.target.value })} />
 );
 
 export default () => {
@@ -31,7 +31,7 @@ export default () => {
                 component={(props) => <MyInput {...props} />}
                 value={data}
                 onChange={(value: any) => setData(value)}
-                initRowValues={INIT_ROW_VALUES}
+                initValues={INIT_ROW_VALUES}
             />
 
             <Button onClick={() => console.log(data)}>控制台查看数据</Button>

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -18,10 +18,10 @@ const INIT_DATA = {
 
 type IRow = typeof INIT_ROW_VALUES;
 
-const MyInput = ({ rowValues: { input }, key, disabled, onChange }: IComponentProps<IRow>) => (
+const MyInput = ({ rowValues: { input }, rowKey, disabled, onChange }: IComponentProps<IRow>) => (
     <Input
         value={input}
-        onChange={(e) => onChange?.(key ?? '', { input: e.target.value })}
+        onChange={(e) => onChange?.(rowKey, { input: e.target.value })}
         disabled={disabled}
     />
 );
@@ -43,7 +43,7 @@ export default () => {
                 <FilterRules<IRow>
                     component={(props) => <MyInput {...props} />}
                     disabled={disabled}
-                    initRowValues={INIT_ROW_VALUES}
+                    initValues={INIT_ROW_VALUES}
                 />
             </Form.Item>
         </Form>

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Form, Input } from 'antd';
 import shortid from 'shortid';
 
-import FilterRules from '..';
+import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -11,34 +11,24 @@ const INIT_ROW_VALUES = {
 const INIT_DATA = {
     key: shortid(),
     level: 0,
-    formValues: {
+    rowValues: {
         ...INIT_ROW_VALUES,
     },
 };
 
 type IRow = typeof INIT_ROW_VALUES;
 
-const MyInput = ({
-    input,
-    rowKey,
-    isEdit,
-    onChange,
-}: {
-    input?: string;
-    rowKey?: string;
-    isEdit?: boolean;
-    onChange?: (key: string, values: Partial<IRow>) => void;
-}) => (
+const MyInput = ({ rowValues: { input }, key, disabled, onChange }: IComponentProps<IRow>) => (
     <Input
         value={input}
-        onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })}
-        disabled={!isEdit}
+        onChange={(e) => onChange?.(key ?? '', { input: e.target.value })}
+        disabled={disabled}
     />
 );
 
 export default () => {
     const [form] = Form.useForm();
-    const [isEdit, useIsEdit] = useState(true);
+    const [disabled, useDisabled] = useState(false);
 
     useEffect(() => {
         form.setFieldsValue({ condition: INIT_DATA });
@@ -46,11 +36,14 @@ export default () => {
 
     return (
         <Form form={form}>
-            <Button style={{ marginBottom: 16 }} onClick={() => useIsEdit(!isEdit)}>
-                {isEdit ? '查看' : '编辑'}状态
+            <Button style={{ marginBottom: 16 }} onClick={() => useDisabled(!disabled)}>
+                {disabled ? '编辑' : '查看'}状态
             </Button>
             <Form.Item name="condition">
-                <FilterRules<IRow> component={<MyInput />} isEdit={isEdit} />
+                <FilterRules<IRow>
+                    component={(props) => <MyInput {...props} />}
+                    disabled={disabled}
+                />
             </Form.Item>
         </Form>
     );

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Input } from 'antd';
+import { FilterRules } from 'dt-react-component';
+import { IComponentProps } from 'dt-react-component/filterRules';
 import shortid from 'shortid';
-
-import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -43,6 +43,7 @@ export default () => {
                 <FilterRules<IRow>
                     component={(props) => <MyInput {...props} />}
                     disabled={disabled}
+                    initRowValues={INIT_ROW_VALUES}
                 />
             </Form.Item>
         </Form>

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -2,21 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Button, Form, Input } from 'antd';
 import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
-import shortid from 'shortid';
 
-const INIT_ROW_VALUES = {
-    input: '',
-};
-
-const INIT_DATA = {
-    key: shortid(),
-    level: 0,
-    rowValues: {
-        ...INIT_ROW_VALUES,
-    },
-};
-
-type IRow = typeof INIT_ROW_VALUES;
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from './basic';
 
 const MyInput = ({ rowValues: { input }, rowKey, disabled, onChange }: IComponentProps<IRow>) => (
     <Input

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Form, Input } from 'antd';
+import shortid from 'shortid';
+
+import FilterRules from '..';
+
+const INIT_ROW_VALUES = {
+    input: '',
+};
+
+const INIT_DATA = {
+    key: shortid(),
+    level: 0,
+    formValues: {
+        ...INIT_ROW_VALUES,
+    },
+};
+
+type IRow = typeof INIT_ROW_VALUES;
+
+const MyInput = ({
+    input,
+    rowKey,
+    isEdit,
+    onChange,
+}: {
+    input?: string;
+    rowKey?: string;
+    isEdit?: boolean;
+    onChange?: (key: string, values: Partial<IRow>) => void;
+}) => (
+    <Input
+        value={input}
+        onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })}
+        disabled={!isEdit}
+    />
+);
+
+export default () => {
+    const [form] = Form.useForm();
+    const [isEdit, useIsEdit] = useState(true);
+
+    useEffect(() => {
+        form.setFieldsValue({ condition: INIT_DATA });
+    }, []);
+
+    return (
+        <Form form={form}>
+            <Button style={{ marginBottom: 16 }} onClick={() => useIsEdit(!isEdit)}>
+                {isEdit ? '查看' : '编辑'}状态
+            </Button>
+            <Form.Item name="condition">
+                <FilterRules<IRow> component={<MyInput />} isEdit={isEdit} />
+            </Form.Item>
+        </Form>
+    );
+};

--- a/src/filterRules/demos/basicCheck.tsx
+++ b/src/filterRules/demos/basicCheck.tsx
@@ -3,7 +3,7 @@ import { Button, Form, Input } from 'antd';
 import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
 
-import { INIT_DATA, INIT_ROW_VALUES, IRow } from './basic';
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from './constants';
 
 const MyInput = ({ rowValues: { input }, rowKey, disabled, onChange }: IComponentProps<IRow>) => (
     <Input

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Form, Input } from 'antd';
 import shortid from 'shortid';
 
-import FilterRules from '..';
+import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -11,22 +11,18 @@ const INIT_ROW_VALUES = {
 const INIT_DATA = {
     key: shortid(),
     level: 0,
-    formValues: {
+    rowValues: {
         ...INIT_ROW_VALUES,
     },
 };
 
 type IRow = typeof INIT_ROW_VALUES;
 
-const MyInput = ({
-    input,
-    rowKey,
-    onChange,
-}: {
-    input?: string;
-    rowKey?: string;
-    onChange?: (key: string, values: Partial<IRow>) => void;
-}) => <Input value={input} onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })} />;
+const MyInput = ({ name }: IComponentProps<IRow>) => (
+    <Form.Item name={['condition', ...name, 'input']}>
+        <Input />
+    </Form.Item>
+);
 
 export default () => {
     const [form] = Form.useForm();
@@ -40,7 +36,7 @@ export default () => {
                 添加数据
             </Button>
             <Form.Item name="condition">
-                <FilterRules<IRow> component={<MyInput />} />
+                <FilterRules<IRow> component={(props) => <MyInput {...props} />} />
             </Form.Item>
             <Button onClick={async () => console.log(await form.validateFields())}>
                 控制台查看数据

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, Form, Input } from 'antd';
+import shortid from 'shortid';
+
+import FilterRules from '..';
+
+const INIT_ROW_VALUES = {
+    input: '',
+};
+
+const INIT_DATA = {
+    key: shortid(),
+    level: 0,
+    formValues: {
+        ...INIT_ROW_VALUES,
+    },
+};
+
+type IRow = typeof INIT_ROW_VALUES;
+
+const MyInput = ({
+    input,
+    rowKey,
+    onChange,
+}: {
+    input?: string;
+    rowKey?: string;
+    onChange?: (key: string, values: Partial<IRow>) => void;
+}) => <Input value={input} onChange={(e) => onChange?.(rowKey ?? '', { input: e.target.value })} />;
+
+export default () => {
+    const [form] = Form.useForm();
+
+    return (
+        <Form form={form}>
+            <Button
+                onClick={() => form.setFieldsValue({ condition: INIT_DATA })}
+                style={{ marginBottom: 16 }}
+            >
+                添加数据
+            </Button>
+            <Form.Item name="condition">
+                <FilterRules<IRow> component={<MyInput />} />
+            </Form.Item>
+            <Button onClick={async () => console.log(await form.validateFields())}>
+                控制台查看数据
+            </Button>
+        </Form>
+    );
+};

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -3,7 +3,7 @@ import { Button, Form, Input } from 'antd';
 import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
 
-import { INIT_DATA, INIT_ROW_VALUES, IRow } from './basic';
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from './constants';
 
 const MyInput = ({ name }: IComponentProps<IRow>) => (
     <Form.Item name={['condition', ...name, 'input']}>

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -2,21 +2,8 @@ import React from 'react';
 import { Button, Form, Input } from 'antd';
 import { FilterRules } from 'dt-react-component';
 import { IComponentProps } from 'dt-react-component/filterRules';
-import shortid from 'shortid';
 
-const INIT_ROW_VALUES = {
-    input: '',
-};
-
-const INIT_DATA = {
-    key: shortid(),
-    level: 0,
-    rowValues: {
-        ...INIT_ROW_VALUES,
-    },
-};
-
-type IRow = typeof INIT_ROW_VALUES;
+import { INIT_DATA, INIT_ROW_VALUES, IRow } from './basic';
 
 const MyInput = ({ name }: IComponentProps<IRow>) => (
     <Form.Item name={['condition', ...name, 'input']}>

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -39,7 +39,7 @@ export default () => {
                 <FilterRules<IRow>
                     component={(props) => <MyInput {...props} />}
                     notEmpty={{ data: false }}
-                    initRowValues={INIT_ROW_VALUES}
+                    initValues={INIT_ROW_VALUES}
                 />
             </Form.Item>
             <Button onClick={async () => console.log(await form.validateFields())}>

--- a/src/filterRules/demos/basicUnController.tsx
+++ b/src/filterRules/demos/basicUnController.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button, Form, Input } from 'antd';
+import { FilterRules } from 'dt-react-component';
+import { IComponentProps } from 'dt-react-component/filterRules';
 import shortid from 'shortid';
-
-import FilterRules, { IComponentProps } from '..';
 
 const INIT_ROW_VALUES = {
     input: '',
@@ -36,7 +36,11 @@ export default () => {
                 添加数据
             </Button>
             <Form.Item name="condition">
-                <FilterRules<IRow> component={(props) => <MyInput {...props} />} />
+                <FilterRules<IRow>
+                    component={(props) => <MyInput {...props} />}
+                    notEmpty={{ data: false }}
+                    initRowValues={INIT_ROW_VALUES}
+                />
             </Form.Item>
             <Button onClick={async () => console.log(await form.validateFields())}>
                 控制台查看数据

--- a/src/filterRules/demos/constants.ts
+++ b/src/filterRules/demos/constants.ts
@@ -1,0 +1,15 @@
+import shortid from 'shortid';
+
+export const INIT_ROW_VALUES = {
+    input: '',
+};
+
+export const INIT_DATA = {
+    key: shortid(),
+    level: 0,
+    rowValues: {
+        ...INIT_ROW_VALUES,
+    },
+};
+
+export type IRow = typeof INIT_ROW_VALUES;

--- a/src/filterRules/index.md
+++ b/src/filterRules/index.md
@@ -24,15 +24,15 @@ demo:
 
 ### FilterRules
 
-| 参数          | 说明                       | 类型                                             | 默认值                                 |
-| ------------- | -------------------------- | ------------------------------------------------ | -------------------------------------- |
-| value         | 数据                       | `IFilterValue<T>`                                | -                                      |
-| disabled      | 编辑/查看状态              | `boolean`                                        | `false`                                |
-| maxLevel      | 条件节点层级               | `number`                                         | 5                                      |
-| component     | 条件节点后展示的组件       | `(props: IComponentProps<T>) => React.ReactNode` | -                                      |
-| initRowValues | 新增的数据默认值           | `T`                                              | `false`                                |
-| notEmpty      | 删除时是否保留最后一行数据 | `{data:boolean;message?:string}`                 | `{data:true;message:"必须有一条数据"}` |
-| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void`  | -                                      |
+| 参数       | 说明                       | 类型                                             | 默认值                                 |
+| ---------- | -------------------------- | ------------------------------------------------ | -------------------------------------- |
+| value      | 数据                       | `IFilterValue<T>`                                | -                                      |
+| disabled   | 编辑/查看状态              | `boolean`                                        | `false`                                |
+| maxLevel   | 条件节点层级               | `number`                                         | 5                                      |
+| component  | 条件节点后展示的组件       | `(props: IComponentProps<T>) => React.ReactNode` | -                                      |
+| initValues | 新增的数据默认值           | `T`                                              | -                                      |
+| notEmpty   | 删除时是否保留最后一行数据 | `{data:boolean;message?:string}`                 | `{data:true;message:"必须有一条数据"}` |
+| onChange   | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void`  | -                                      |
 
 ### IFilterValue
 

--- a/src/filterRules/index.md
+++ b/src/filterRules/index.md
@@ -24,25 +24,32 @@ demo:
 
 ### FilterRules
 
-| 参数          | 说明                       | 类型                                            | 默认值  |
-| ------------- | -------------------------- | ----------------------------------------------- | ------- |
-| value         | 数据                       | `IFilterValue<T>`                               | -       |
-| isEdit        | 编辑/查看状态              | `boolean`                                       | `true`  |
-| maxLevel      | 条件节点层级               | `number`                                        | 5       |
-| component     | 条件节点后展示的组件       | `JSX.Element`                                   | -       |
-| initRowValues | 新增的数据默认值           | `T`                                             | `false` |
-| notEmpty      | 删除时是否保留最后一行数据 | `boolean`                                       | `true`  |
-| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void` | -       |
+| 参数          | 说明                       | 类型                                             | 默认值  |
+| ------------- | -------------------------- | ------------------------------------------------ | ------- |
+| value         | 数据                       | `IFilterValue<T>`                                | -       |
+| disabled      | 编辑/查看状态              | `boolean`                                        | `false` |
+| maxLevel      | 条件节点层级               | `number`                                         | 5       |
+| component     | 条件节点后展示的组件       | `(props: IComponentProps<T>) => React.ReactNode` | -       |
+| initRowValues | 新增的数据默认值           | `T`                                              | `false` |
+| notEmpty      | 删除时是否保留最后一行数据 | `boolean`                                        | `true`  |
+| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void`  | -       |
 
 ### IFilterValue
 
-| 参数       | 说明                       | 类型                | 默认值 |
-| ---------- | -------------------------- | ------------------- | ------ |
-| key        | 唯一标识                   | `string`            | -      |
-| level      | 节点层级                   | `boolean`           | -      |
-| type       | 条件节点类型               | `number`            | -      |
-| lineHeight | 节点的线条高度             | `number`            | -      |
-| height     | 节点的高度                 | `number`            | -      |
-| bottom     | 线条距离节点底部高度       | `number`            | -      |
-| formValues | 数据改变的回调函数         | `T`                 | -      |
-| children   | 子节点(存在条件节点时存在) | `IFilterValue<T>[]` | -      |
+| 参数      | 说明                       | 类型                | 默认值 |
+| --------- | -------------------------- | ------------------- | ------ |
+| key       | 唯一标识                   | `string`            | -      |
+| level     | 节点层级                   | `boolean`           | -      |
+| type      | 条件节点类型               | `1｜2`              | -      |
+| rowValues | 节点数据                   | `T`                 | -      |
+| children  | 子节点(存在条件节点时存在) | `IFilterValue<T>[]` | -      |
+
+### IComponentProps
+
+| 参数      | 说明                       | 类型                               | 默认值 |
+| --------- | -------------------------- | ---------------------------------- | ------ |
+| key       | 唯一标识                   | `string`                           | -      |
+| disabled  | 编辑/查看状态              | `boolean`                          | -      |
+| name      | 字段名                     | `InternalNamePath`                 | -      |
+| rowValues | 节点数据                   | `T`                                | -      |
+| onChange  | 子节点(存在条件节点时存在) | `(key: string, values: T) => void` | -      |

--- a/src/filterRules/index.md
+++ b/src/filterRules/index.md
@@ -24,15 +24,15 @@ demo:
 
 ### FilterRules
 
-| 参数          | 说明                       | 类型                                             | 默认值  |
-| ------------- | -------------------------- | ------------------------------------------------ | ------- |
-| value         | 数据                       | `IFilterValue<T>`                                | -       |
-| disabled      | 编辑/查看状态              | `boolean`                                        | `false` |
-| maxLevel      | 条件节点层级               | `number`                                         | 5       |
-| component     | 条件节点后展示的组件       | `(props: IComponentProps<T>) => React.ReactNode` | -       |
-| initRowValues | 新增的数据默认值           | `T`                                              | `false` |
-| notEmpty      | 删除时是否保留最后一行数据 | `boolean`                                        | `true`  |
-| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void`  | -       |
+| 参数          | 说明                       | 类型                                             | 默认值                                 |
+| ------------- | -------------------------- | ------------------------------------------------ | -------------------------------------- |
+| value         | 数据                       | `IFilterValue<T>`                                | -                                      |
+| disabled      | 编辑/查看状态              | `boolean`                                        | `false`                                |
+| maxLevel      | 条件节点层级               | `number`                                         | 5                                      |
+| component     | 条件节点后展示的组件       | `(props: IComponentProps<T>) => React.ReactNode` | -                                      |
+| initRowValues | 新增的数据默认值           | `T`                                              | `false`                                |
+| notEmpty      | 删除时是否保留最后一行数据 | `{data:boolean;message?:string}`                 | `{data:true;message:"必须有一条数据"}` |
+| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void`  | -                                      |
 
 ### IFilterValue
 

--- a/src/filterRules/index.md
+++ b/src/filterRules/index.md
@@ -1,0 +1,46 @@
+---
+title: FilterRules 且或组件
+group: 组件
+toc: content
+demo:
+    cols: 2
+---
+
+# FilterRules 且或组件
+
+用于一些需要且或关系数据填入/展示
+
+## 何时使用
+
+适合使用在且或关系数据填入/展示
+
+## 示例
+
+<code src="./demos/basic.tsx" >受控方式使用</code>
+
+## API
+
+### FilterRules
+
+| 参数          | 说明                       | 类型                                            | 默认值  |
+| ------------- | -------------------------- | ----------------------------------------------- | ------- |
+| value         | 数据                       | `IFilterValue<T>`                               | -       |
+| isEdit        | 编辑/查看状态              | `boolean`                                       | `true`  |
+| maxLevel      | 条件节点层级               | `number`                                        | 5       |
+| component     | 条件节点后展示的组件       | `JSX.Element`                                   | -       |
+| initRowValues | 新增的数据默认值           | `T`                                             | `false` |
+| notEmpty      | 删除时是否保留最后一行数据 | `boolean`                                       | `true`  |
+| onChange      | 数据改变的回调函数         | `(value: IFilterValue<T> \| undefined) => void` | -       |
+
+### IFilterValue
+
+| 参数       | 说明                       | 类型                | 默认值 |
+| ---------- | -------------------------- | ------------------- | ------ |
+| key        | 唯一标识                   | `string`            | -      |
+| level      | 节点层级                   | `boolean`           | -      |
+| type       | 条件节点类型               | `number`            | -      |
+| lineHeight | 节点的线条高度             | `number`            | -      |
+| height     | 节点的高度                 | `number`            | -      |
+| bottom     | 线条距离节点底部高度       | `number`            | -      |
+| formValues | 数据改变的回调函数         | `T`                 | -      |
+| children   | 子节点(存在条件节点时存在) | `IFilterValue<T>[]` | -      |

--- a/src/filterRules/index.md
+++ b/src/filterRules/index.md
@@ -3,7 +3,7 @@ title: FilterRules 且或组件
 group: 组件
 toc: content
 demo:
-    cols: 2
+    cols: 1
 ---
 
 # FilterRules 且或组件
@@ -17,6 +17,8 @@ demo:
 ## 示例
 
 <code src="./demos/basic.tsx" >受控方式使用</code>
+<code src="./demos/basicUnController.tsx" >非受控方式使用</code>
+<code src="./demos/basicCheck.tsx" >查看数据</code>
 
 ## API
 

--- a/src/filterRules/index.tsx
+++ b/src/filterRules/index.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { message } from 'antd';
+import { clone } from 'lodash';
+import shortId from 'shortid';
+
+import { RulesController } from './ruleController';
+
+export enum ROW_PERMISSION_RELATION {
+    AND = 1,
+    OR = 2,
+}
+export const ROW_PERMISSION_RELATION_TEXT = {
+    [ROW_PERMISSION_RELATION.AND]: '且',
+    [ROW_PERMISSION_RELATION.OR]: '或',
+};
+
+export interface IFilterValue<T> {
+    key: string;
+    level?: number;
+    type?: number;
+    lineHeight?: number;
+    height?: number;
+    bottom?: number;
+    formValues?: T;
+    children?: IFilterValue<T>[];
+}
+
+interface IProps<T> {
+    value?: IFilterValue<T>;
+    isEdit?: boolean;
+    maxLevel?: number;
+    component: JSX.Element;
+    initRowValues?: T;
+    notEmpty?: boolean;
+    onChange?: (value: IFilterValue<T> | undefined) => void;
+}
+
+const FilterRules = <T,>(props: IProps<T>) => {
+    const {
+        component,
+        maxLevel = 5,
+        isEdit = true,
+        notEmpty = true,
+        value,
+        initRowValues,
+        onChange,
+    } = props;
+
+    const finRelationNode = (
+        parentData: IFilterValue<T>,
+        targetKey: string,
+        needCurrent?: boolean
+    ): IFilterValue<T> | null | undefined => {
+        const parentDataTemp = parentData;
+        if (parentDataTemp.key === targetKey) return parentDataTemp;
+        if (!parentDataTemp.children?.length) return null;
+        for (let i = 0; i < parentDataTemp.children.length; i++) {
+            const current = parentDataTemp.children[i];
+            if (current.key === targetKey) return needCurrent ? current : parentDataTemp;
+            const node: IFilterValue<T> | null | undefined = finRelationNode(
+                current,
+                targetKey,
+                needCurrent
+            );
+            if (node) return node;
+        }
+    };
+
+    const handleAddCondition = (keyObj: { key: string; isOut?: boolean }) => {
+        const cloneData = clone(value);
+        const appendNode = finRelationNode(cloneData as IFilterValue<T>, keyObj.key, keyObj.isOut);
+        addCondition(appendNode, keyObj, initRowValues as T);
+        onChange?.(cloneData);
+    };
+
+    const addCondition = (
+        treeNode: any,
+        keyObj: { key: string; isOut?: boolean },
+        initRowValue: T
+    ) => {
+        const key = keyObj.key;
+        if (keyObj.isOut)
+            return treeNode.children.push(
+                Object.assign(
+                    {},
+                    { formValues: initRowValue },
+                    { key: shortId(), level: treeNode.level }
+                )
+            );
+        const children = treeNode?.children;
+        if (!children) {
+            const newNode = {
+                key: treeNode.key,
+                level: treeNode.level + 1,
+                type: ROW_PERMISSION_RELATION.AND,
+                children: [
+                    { formValues: treeNode.formValues, key: shortId(), level: treeNode?.level + 1 },
+                    { formValues: initRowValue, key: shortId(), level: treeNode?.level + 1 },
+                ],
+            };
+            delete treeNode.formValues;
+            Object.assign(treeNode, newNode);
+            return;
+        }
+        for (let i = 0; i < children.length; i += 1) {
+            if (children[i].key !== key) continue;
+            if (treeNode?.level <= maxLevel) {
+                children[i] = {
+                    key: children[i].key,
+                    type: ROW_PERMISSION_RELATION.AND,
+                    level: treeNode?.level + 1,
+                    children: [
+                        Object.assign({}, children[i], {
+                            key: shortId(),
+                            level: treeNode?.level + 1,
+                        }),
+                        Object.assign(
+                            {},
+                            { formValues: initRowValue },
+                            {
+                                key: shortId(),
+                                level: treeNode?.level + 1,
+                            }
+                        ),
+                    ],
+                };
+            }
+        }
+    };
+
+    const handleDeleteCondition = (key: string) => {
+        const cloneData = clone(value);
+        const deleteNode = finRelationNode(cloneData as IFilterValue<T>, key, false);
+        if (notEmpty && !deleteNode?.children) return message.info('必须有一条数据');
+        if (!notEmpty && !deleteNode?.children) {
+            return onChange?.(undefined);
+        }
+        deleteCondition(deleteNode as IFilterValue<T>, key);
+        onChange?.(cloneData);
+    };
+
+    const deleteCondition = (parentData: IFilterValue<T>, key: string) => {
+        let parentDataTemp = parentData;
+        parentDataTemp.children = parentDataTemp?.children?.filter((item) => item.key !== key);
+        if (parentDataTemp?.children?.length === 1) {
+            const newChild = updateLevel(parentDataTemp.children[0]);
+            const key = parentDataTemp.key;
+            delete parentDataTemp.children;
+            delete parentDataTemp.type;
+            parentDataTemp = Object.assign(parentDataTemp, {
+                ...newChild,
+                key,
+                level: newChild.level,
+            });
+        }
+    };
+
+    const updateLevel = (node: IFilterValue<T>) => {
+        let newChildren;
+        if (node.children) newChildren = node.children.map((element) => updateLevel(element));
+        const newNode: IFilterValue<T> = {
+            ...node,
+            children: newChildren,
+            level: (node?.level as number) - 1,
+        };
+        return newNode;
+    };
+
+    const handleChangeCondition = (key: string, type: ROW_PERMISSION_RELATION) => {
+        const cloneData = clone(value);
+        const changeNode = finRelationNode(
+            cloneData as IFilterValue<T>,
+            key,
+            true
+        ) as IFilterValue<T>;
+        changeNode.type =
+            type === ROW_PERMISSION_RELATION.AND
+                ? ROW_PERMISSION_RELATION.OR
+                : ROW_PERMISSION_RELATION.AND;
+        onChange?.(cloneData);
+    };
+
+    const handleChangeFormValues = (key: string, values: T) => {
+        const cloneData = clone(value);
+        const changeNode = finRelationNode(
+            cloneData as IFilterValue<T>,
+            key,
+            true
+        ) as IFilterValue<T>;
+        changeNode.formValues = {
+            ...(changeNode.formValues ?? {}),
+            ...values,
+        };
+        onChange?.(cloneData);
+    };
+
+    return (
+        <RulesController<T>
+            maxLevel={maxLevel}
+            isEdit={isEdit}
+            value={value}
+            component={component}
+            onAddCondition={handleAddCondition}
+            onDeleteCondition={handleDeleteCondition}
+            onChangeCondition={handleChangeCondition}
+            onChangeFormValues={handleChangeFormValues}
+        />
+    );
+};
+
+export default FilterRules;

--- a/src/filterRules/index.tsx
+++ b/src/filterRules/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { message } from 'antd';
+import { InternalNamePath } from 'antd/lib/form/interface';
 import { clone } from 'lodash';
 import shortId from 'shortid';
 
@@ -14,24 +15,29 @@ export const ROW_PERMISSION_RELATION_TEXT = {
     [ROW_PERMISSION_RELATION.OR]: '或',
 };
 
+export interface IComponentProps<T> {
+    key: string;
+    disabled: boolean;
+    name: InternalNamePath;
+    rowValues: T;
+    onChange: (key: string, values: T) => void;
+}
+
 export interface IFilterValue<T> {
     key: string;
     level?: number;
     type?: number;
-    lineHeight?: number;
-    height?: number;
-    bottom?: number;
-    formValues?: T;
+    rowValues?: T;
     children?: IFilterValue<T>[];
 }
 
 interface IProps<T> {
     value?: IFilterValue<T>;
-    isEdit?: boolean;
+    disabled?: boolean;
     maxLevel?: number;
-    component: JSX.Element;
     initRowValues?: T;
     notEmpty?: boolean;
+    component: (props: IComponentProps<T>) => React.ReactNode;
     onChange?: (value: IFilterValue<T> | undefined) => void;
 }
 
@@ -39,7 +45,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
     const {
         component,
         maxLevel = 5,
-        isEdit = true,
+        disabled = false,
         notEmpty = true,
         value,
         initRowValues,
@@ -83,7 +89,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
             return treeNode.children.push(
                 Object.assign(
                     {},
-                    { formValues: initRowValue },
+                    { rowValues: initRowValue },
                     { key: shortId(), level: treeNode.level }
                 )
             );
@@ -94,11 +100,11 @@ const FilterRules = <T,>(props: IProps<T>) => {
                 level: treeNode.level + 1,
                 type: ROW_PERMISSION_RELATION.AND,
                 children: [
-                    { formValues: treeNode.formValues, key: shortId(), level: treeNode?.level + 1 },
-                    { formValues: initRowValue, key: shortId(), level: treeNode?.level + 1 },
+                    { rowValues: treeNode.rowValues, key: shortId(), level: treeNode?.level + 1 },
+                    { rowValues: initRowValue, key: shortId(), level: treeNode?.level + 1 },
                 ],
             };
-            delete treeNode.formValues;
+            delete treeNode.rowValues;
             Object.assign(treeNode, newNode);
             return;
         }
@@ -116,7 +122,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
                         }),
                         Object.assign(
                             {},
-                            { formValues: initRowValue },
+                            { rowValues: initRowValue },
                             {
                                 key: shortId(),
                                 level: treeNode?.level + 1,
@@ -180,15 +186,15 @@ const FilterRules = <T,>(props: IProps<T>) => {
         onChange?.(cloneData);
     };
 
-    const handleChangeFormValues = (key: string, values: T) => {
+    const handleChangeRowValues = (key: string, values: T) => {
         const cloneData = clone(value);
         const changeNode = finRelationNode(
             cloneData as IFilterValue<T>,
             key,
             true
         ) as IFilterValue<T>;
-        changeNode.formValues = {
-            ...(changeNode.formValues ?? {}),
+        changeNode.rowValues = {
+            ...(changeNode.rowValues ?? {}),
             ...values,
         };
         onChange?.(cloneData);
@@ -197,13 +203,13 @@ const FilterRules = <T,>(props: IProps<T>) => {
     return (
         <RulesController<T>
             maxLevel={maxLevel}
-            isEdit={isEdit}
+            disabled={disabled}
             value={value}
             component={component}
             onAddCondition={handleAddCondition}
             onDeleteCondition={handleDeleteCondition}
             onChangeCondition={handleChangeCondition}
-            onChangeFormValues={handleChangeFormValues}
+            onChangeRowValues={handleChangeRowValues}
         />
     );
 };

--- a/src/filterRules/index.tsx
+++ b/src/filterRules/index.tsx
@@ -16,7 +16,7 @@ export const ROW_PERMISSION_RELATION_TEXT = {
 };
 
 export interface IComponentProps<T> {
-    key: string;
+    rowKey: string;
     disabled: boolean;
     name: InternalNamePath;
     rowValues: T;
@@ -35,7 +35,7 @@ interface INormalProps<T> {
     value?: IFilterValue<T>;
     disabled?: false;
     maxLevel?: number;
-    initRowValues: T;
+    initValues: T;
     notEmpty?: { data: boolean; message?: string };
     component: (props: IComponentProps<T>) => React.ReactNode;
     onChange?: (value: IFilterValue<T> | undefined) => void;
@@ -58,7 +58,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
     const {
         maxLevel = 5,
         notEmpty = { data: true, message: '必须有一条数据' },
-        initRowValues,
+        initValues,
         onChange,
     } = (!isDisabled(props) && props) as INormalProps<T>;
 
@@ -86,7 +86,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
     const handleAddCondition = (keyObj: { key: string; isOut?: boolean }) => {
         const cloneData = clone(value);
         const appendNode = finRelationNode(cloneData as IFilterValue<T>, keyObj.key, keyObj.isOut);
-        addCondition(appendNode, keyObj, initRowValues as T);
+        addCondition(appendNode, keyObj, initValues as T);
         onChange?.(cloneData);
     };
 
@@ -133,14 +133,11 @@ const FilterRules = <T,>(props: IProps<T>) => {
                             key: shortId(),
                             level: treeNode?.level + 1,
                         }),
-                        Object.assign(
-                            {},
-                            { rowValues: initRowValue },
-                            {
-                                key: shortId(),
-                                level: treeNode?.level + 1,
-                            }
-                        ),
+                        Object.assign({
+                            key: shortId(),
+                            rowValues: initRowValue,
+                            level: treeNode?.level + 1,
+                        }),
                     ],
                 };
             }
@@ -217,7 +214,7 @@ const FilterRules = <T,>(props: IProps<T>) => {
         };
         onChange?.(cloneData);
     };
-
+    console.log(value);
     return (
         <RulesController<T>
             maxLevel={maxLevel}

--- a/src/filterRules/index.tsx
+++ b/src/filterRules/index.tsx
@@ -16,35 +16,35 @@ export const ROW_PERMISSION_RELATION_TEXT = {
 };
 
 export interface IComponentProps<T> {
-    rowKey: string;
-    disabled: boolean;
-    name: InternalNamePath;
-    rowValues: T;
-    onChange: (key: string, values: T) => void;
+    rowKey: string; // 当前节点的唯一标识
+    disabled: boolean; // 编辑/查看状态
+    name: InternalNamePath; // 使用 Form.Item 时，中间的 NamePath
+    rowValues: T; // 自定义钻的数据
+    onChange: (key: string, values: T) => void; // 改变数据的方法
 }
 
 export interface IFilterValue<T> {
     key: string;
-    level?: number;
-    type?: number;
-    rowValues?: T;
-    children?: IFilterValue<T>[];
+    level?: number; // 当前节点的层级，用于判断一些按钮的展示
+    type?: number; // 当前节点的条件关系，1 | 2
+    rowValues?: T; // Form 节点的相关的信息(子节点无条件节点时才有)
+    children?: IFilterValue<T>[]; // 子节点的信息(子节点存在条件节点时才有)
 }
 
 interface INormalProps<T> {
-    value?: IFilterValue<T>;
-    disabled?: false;
-    maxLevel?: number;
-    initValues: T;
-    notEmpty?: { data: boolean; message?: string };
-    component: (props: IComponentProps<T>) => React.ReactNode;
-    onChange?: (value: IFilterValue<T> | undefined) => void;
+    value?: IFilterValue<T>; // 组件的值
+    disabled?: false; // 编辑状态
+    maxLevel?: number; // 节点层级
+    initValues: T; // 自定义组件的初始值
+    notEmpty?: { data: boolean; message?: string }; // 是否保留最后一条数据
+    component: (props: IComponentProps<T>) => React.ReactNode; // 自定义展示组件
+    onChange?: (value: IFilterValue<T> | undefined) => void; // 改变数据的方法
 }
 
 interface IDisabledProps<T> {
-    value?: IFilterValue<T>;
-    disabled: true;
-    component: (props: IComponentProps<T>) => React.ReactNode;
+    value?: IFilterValue<T>; // 组件的值
+    disabled: true; // 查看状态
+    component: (props: IComponentProps<T>) => React.ReactNode; // 自定义展示组件
 }
 
 function isDisabled<T>(props: IProps<T>): props is IDisabledProps<T> {
@@ -214,7 +214,6 @@ const FilterRules = <T,>(props: IProps<T>) => {
         };
         onChange?.(cloneData);
     };
-    console.log(value);
     return (
         <RulesController<T>
             maxLevel={maxLevel}

--- a/src/filterRules/ruleController/index.scss
+++ b/src/filterRules/ruleController/index.scss
@@ -1,0 +1,105 @@
+.ruleController {
+    &__condition {
+        position: relative;
+        .ruleController__condition--active {
+            padding-left: 32px;
+            .condition__box--line {
+                width: 33px;
+                height: 2px;
+                display: inline-block;
+                background-color: #DDEFFF;
+                position: absolute;
+                top: 50%;
+                left: -33px;
+                &.disabled {
+                    background-color: #EBECF0;
+                }
+            }
+        }
+        .condition {
+            &__box {
+                position: absolute;
+                border: 1px solid #DDEFFF;
+                &.disabled {
+                    border-color: #EBECF0;
+                }
+                &--name {
+                    cursor: pointer;
+                    position: absolute;
+                    left: -14px;
+                    top: 50%;
+                    margin-top: -13px;
+                    background: #DDEFFF;
+                    width: 27px;
+                    height: 27px;
+                    border-radius: 50%;
+                    font-size: 12px;
+                    color: #2491F7;
+                    text-align: center;
+                    line-height: 26px;
+                    z-index: 10;
+                    &.disabled {
+                        cursor: not-allowed;
+                        color: #3D446E;
+                        background: #EBECF0;
+                    }
+                }
+            }
+            &__add {
+                display: flex;
+                height: 32px;
+                &--line {
+                    display: block;
+                    width: 30px;
+                    height: 2px;
+                    background-color: #DDEFFF;
+                    margin-top: 16px;
+                }
+                &--icon {
+                    cursor: pointer;
+                    color: #3F87FF;
+                    font-size: 18px;
+                    margin-top: 7px;
+                }
+            }
+        }
+    }
+    &__item {
+        display: flex;
+        min-width: 0;
+        flex: 1;
+        align-items: center;
+        margin-bottom: 16px;
+        &--line {
+            width: 30px;
+            height: 2px;
+            background: #DDEFFF;
+            display: block;
+            &.disabled {
+                background-color: #EBECF0;
+            }
+        }
+        &--component {
+            flex: 1;
+        }
+        &--operation {
+            width: 10%;
+            margin-left: 12px;
+            margin-top: 7px;
+            .icon {
+                cursor: pointer;
+                color: #3F87FF;
+                font-size: 18px;
+                &:first-child {
+                    margin-right: 8px;
+                }
+            }
+        }
+    }
+    .ant-form-item {
+        margin-bottom: 0;
+        .ant-form-item-explain .ant-form-item-explain-error {
+            position: absolute;
+        }
+    }
+}

--- a/src/filterRules/ruleController/index.scss
+++ b/src/filterRules/ruleController/index.scss
@@ -7,7 +7,7 @@
                 width: 33px;
                 height: 2px;
                 display: inline-block;
-                background-color: #DDEFFF;
+                background-color: #E8F1FF;
                 position: absolute;
                 top: 50%;
                 left: -33px;
@@ -19,7 +19,7 @@
         .condition {
             &__box {
                 position: absolute;
-                border: 1px solid #DDEFFF;
+                border: 1px solid #E8F1FF;
                 &.disabled {
                     border-color: #EBECF0;
                 }
@@ -29,12 +29,12 @@
                     left: -14px;
                     top: 50%;
                     margin-top: -13px;
-                    background: #DDEFFF;
+                    background: #DDEBFF;
                     width: 27px;
                     height: 27px;
                     border-radius: 50%;
                     font-size: 12px;
-                    color: #2491F7;
+                    color: #1D78FF;
                     text-align: center;
                     line-height: 26px;
                     z-index: 10;
@@ -52,14 +52,14 @@
                     display: block;
                     width: 30px;
                     height: 2px;
-                    background-color: #DDEFFF;
+                    background-color: #E8F1FF;
                     margin-top: 16px;
                 }
                 &--icon {
                     cursor: pointer;
-                    color: #3F87FF;
+                    color: #1D78FF;
                     font-size: 18px;
-                    margin-top: 7px;
+                    margin: 7px 0 0 12px;
                 }
             }
         }
@@ -73,7 +73,7 @@
         &--line {
             width: 30px;
             height: 2px;
-            background: #DDEFFF;
+            background: #E8F1FF;
             display: block;
             &.disabled {
                 background-color: #EBECF0;
@@ -88,7 +88,7 @@
             margin-top: 7px;
             .icon {
                 cursor: pointer;
-                color: #3F87FF;
+                color: #1D78FF;
                 font-size: 18px;
                 &:first-child {
                     margin-right: 8px;

--- a/src/filterRules/ruleController/index.tsx
+++ b/src/filterRules/ruleController/index.tsx
@@ -125,7 +125,7 @@ export const RulesController = <T,>(props: IProps<T>) => {
         if (item?.children?.length) {
             const childrenPath = (index: number) => {
                 const newPath = [...namePath];
-                newPath.push(...['children', index, 'rowValues']);
+                newPath.push(...['children', index]);
                 return newPath;
             };
             const { lineHeight, bottom } = weakMap.get(item);
@@ -192,9 +192,9 @@ export const RulesController = <T,>(props: IProps<T>) => {
                 )}
                 <div className="ruleController__item--component">
                     {component({
-                        key: item.key,
+                        rowKey: item.key,
                         disabled,
-                        name: !namePath.length ? ['rowValues'] : namePath,
+                        name: [...namePath, 'rowValues'],
                         rowValues: item.rowValues as T,
                         onChange: onChangeRowValues,
                     })}

--- a/src/filterRules/ruleController/index.tsx
+++ b/src/filterRules/ruleController/index.tsx
@@ -12,14 +12,14 @@ import {
 import './index.scss';
 
 interface IProps<T> {
-    value: IFilterValue<T> | undefined;
-    disabled?: boolean;
-    maxLevel: number;
-    component: (props: IComponentProps<T>) => React.ReactNode;
-    onAddCondition: (value: { key: string; isOut?: boolean }) => void;
-    onDeleteCondition: (key: string) => void;
-    onChangeCondition: (key: string, type: ROW_PERMISSION_RELATION) => void;
-    onChangeRowValues: (key: string, values: T) => void;
+    value: IFilterValue<T> | undefined; // 组件的值
+    disabled?: boolean; // 编辑/查看状态
+    maxLevel: number; // 节点层级
+    component: (props: IComponentProps<T>) => React.ReactNode; // 自定义展示组件
+    onAddCondition: (value: { key: string; isOut?: boolean }) => void; // 新增节点
+    onDeleteCondition: (key: string) => void; // 删除节点
+    onChangeCondition: (key: string, type: ROW_PERMISSION_RELATION) => void; // 改变条件节点的值
+    onChangeRowValues: (key: string, values: T) => void; // 改变自定义组件的数据
 }
 
 const ITEM_HEIGHT = 32;

--- a/src/filterRules/ruleController/index.tsx
+++ b/src/filterRules/ruleController/index.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import { MinusCircleOutlined, PlusCircleOutlined } from '@ant-design/icons';
+import { NamePath } from 'antd/lib/form/interface';
+import classnames from 'classnames';
+import { cloneDeep } from 'lodash';
+
+import { IFilterValue, ROW_PERMISSION_RELATION, ROW_PERMISSION_RELATION_TEXT } from '..';
+import './index.scss';
+
+interface IProps<T> {
+    disabled?: boolean; // 是否禁用
+    value: IFilterValue<T> | undefined;
+    isEdit?: boolean;
+    name?: NamePath;
+    maxLevel: number;
+    component: JSX.Element;
+    onAddCondition: (value: { key: string; isOut?: boolean }) => void;
+    onDeleteCondition: (key: string) => void;
+    onChangeCondition: (key: string, type: ROW_PERMISSION_RELATION) => void;
+    onChangeFormValues: (key: string, values: T) => void;
+}
+
+const ITEM_HEIGHT = 32;
+const MARGIN = 16;
+
+export const RulesController = <T,>(props: IProps<T>) => {
+    const {
+        value,
+        isEdit,
+        maxLevel,
+        component,
+        onAddCondition,
+        onDeleteCondition,
+        onChangeCondition,
+        onChangeFormValues,
+    } = props;
+
+    const isCondition = (item: IFilterValue<T>) =>
+        item?.type &&
+        [ROW_PERMISSION_RELATION.AND, ROW_PERMISSION_RELATION.OR].includes(item?.type);
+
+    const calculateTreeItemHeight = (item: IFilterValue<T>, isEdit: boolean) => {
+        if (!item?.children)
+            return { ...item, height: ITEM_HEIGHT + MARGIN, lineHeight: ITEM_HEIGHT };
+        item.children = item.children.map((child) => calculateTreeItemHeight(child, isEdit));
+        const isLastCondition = !item.children.some(isCondition);
+        const firstNodeIsCondition = isCondition(item.children[0]);
+        if (isEdit) {
+            item.height = item.children.reduce(
+                (prev, curr) => prev + (curr?.height as number),
+                ITEM_HEIGHT
+            );
+            // 如果当前节点是最后的判断节点
+            if (isLastCondition) {
+                const firstNodeLineHeight = (item.children[0]?.height as number) - MARGIN;
+                const lastNodeHeight = ITEM_HEIGHT;
+                item.lineHeight = item.height - firstNodeLineHeight / 2 - lastNodeHeight / 2;
+            } else {
+                const firstNodeLineHeight = firstNodeIsCondition
+                    ? (item.children[0].lineHeight as number) / 2 + ITEM_HEIGHT / 2
+                    : ITEM_HEIGHT / 2 + MARGIN;
+                item.lineHeight =
+                    firstNodeLineHeight +
+                    item.children
+                        ?.slice(1)
+                        .reduce((prev, curr) => prev + (curr?.height as number), ITEM_HEIGHT / 2);
+            }
+        } else {
+            item.height = item.children.reduce((prev, curr) => prev + (curr?.height as number), 0);
+            // 如果当前节点是最后的判断节点
+            if (isLastCondition) {
+                item.lineHeight = item.height - ITEM_HEIGHT - MARGIN;
+            } else {
+                const firstNode = item.children[0];
+                const lastNode = item.children[item.children.length - 1];
+                const firstNodeLineHeight =
+                    (firstNode?.height as number) - getNodeReduceHeight(item, true);
+                const lastNodeIsCondition = isCondition(lastNode);
+                const reduceLastHeight = getNodeReduceHeight(item, false);
+                const lastNodeLineHeight = (lastNode?.height as number) - MARGIN - reduceLastHeight;
+                item.bottom = lastNodeIsCondition ? reduceLastHeight : ITEM_HEIGHT / 2;
+                item.lineHeight =
+                    firstNodeLineHeight +
+                    item.children
+                        ?.slice(1, -1)
+                        .reduce((prev, curr) => prev + (curr.height as number), 0) +
+                    lastNodeLineHeight;
+            }
+        }
+        return item;
+    };
+
+    const getNodeReduceHeight = (item: IFilterValue<T>, isFirst: boolean): number => {
+        const currentNode = isFirst
+            ? item?.children?.[0]
+            : item?.children?.[item?.children?.length - 1];
+        if (!currentNode) return ITEM_HEIGHT / 2;
+        const currentNodeIsCondition = isCondition(currentNode);
+        if (currentNodeIsCondition) {
+            return (
+                (currentNode?.lineHeight as number) / 2 + getNodeReduceHeight(currentNode, isFirst)
+            );
+        }
+        return ITEM_HEIGHT / 2;
+    };
+
+    const renderCondition = (item: IFilterValue<T>, namePath: NamePath[], disabled: boolean) => {
+        if (item?.children?.length) {
+            const childrenPath = (index: number) => {
+                const newPath = [...namePath];
+                newPath.push(...['children', index, 'formValues']);
+                return newPath;
+            };
+            return (
+                <div
+                    key={item.key}
+                    className={classnames('ruleController__condition', {
+                        'ruleController__condition--active': item.children.length > 1,
+                    })}
+                >
+                    <div
+                        className={classnames('condition__box', {
+                            disabled: !isEdit,
+                        })}
+                        style={{ height: item.lineHeight, bottom: item?.bottom ?? MARGIN }}
+                    >
+                        <span
+                            className={classnames('condition__box--name', {
+                                disabled: !isEdit,
+                            })}
+                            onClick={() =>
+                                onChangeCondition(item.key, item?.type as ROW_PERMISSION_RELATION)
+                            }
+                        >
+                            {ROW_PERMISSION_RELATION_TEXT[item?.type as ROW_PERMISSION_RELATION]}
+                        </span>
+                        {item.children.length > 1 && (
+                            <span
+                                className={classnames('condition__box--line', {
+                                    disabled: !isEdit,
+                                })}
+                            />
+                        )}
+                    </div>
+                    {item.children.map((d, index) =>
+                        renderCondition(d, childrenPath(index), disabled)
+                    )}
+                    {isEdit && (
+                        <div className="condition__add">
+                            <span className="condition__add--line" />
+                            <PlusCircleOutlined
+                                className="condition__add--icon"
+                                onClick={() =>
+                                    onAddCondition({
+                                        key: item.key,
+                                        isOut: true,
+                                    })
+                                }
+                            />
+                        </div>
+                    )}
+                </div>
+            );
+        }
+        return (
+            <div className="ruleController__item" id={item.key}>
+                {value?.children && (
+                    <span
+                        className={classnames('ruleController__item--line', {
+                            disabled: !isEdit,
+                        })}
+                    />
+                )}
+                <div className="ruleController__item--component">
+                    {React.cloneElement(component, {
+                        rowKey: item.key,
+                        isEdit,
+                        name: namePath,
+                        ...item.formValues,
+                        onChange: onChangeFormValues,
+                    })}
+                </div>
+                {isEdit && (
+                    <div className="ruleController__item--operation">
+                        {item.level === maxLevel ? null : (
+                            <PlusCircleOutlined
+                                className="icon"
+                                onClick={() => {
+                                    onAddCondition({ key: item.key });
+                                }}
+                            />
+                        )}
+                        <MinusCircleOutlined
+                            className="icon"
+                            onClick={() => onDeleteCondition(item.key)}
+                        />
+                    </div>
+                )}
+            </div>
+        );
+    };
+    if (!value) return null;
+    const renderData = calculateTreeItemHeight(cloneDeep(value), !!isEdit);
+    return <div className="ruleController">{renderCondition(renderData, [], !isEdit)}</div>;
+};

--- a/src/filterRules/ruleController/index.tsx
+++ b/src/filterRules/ruleController/index.tsx
@@ -44,12 +44,14 @@ export const RulesController = <T,>(props: IProps<T>) => {
         item?.type &&
         [ROW_PERMISSION_RELATION.AND, ROW_PERMISSION_RELATION.OR].includes(item?.type);
 
+    // 计算每个节点的高度(height)/线条高度(lineHeight)/距离底部高度(bottom)
     const calculateTreeItemHeight = (item: IFilterValue<T>, disabled: boolean) => {
         if (!item?.children)
             return weakMap.set(item, { height: ITEM_HEIGHT + MARGIN, lineHeight: ITEM_HEIGHT });
         item.children.map((child) => calculateTreeItemHeight(child, disabled));
         const isLastCondition = !item.children.some(isCondition);
         const firstNodeIsCondition = isCondition(item.children[0]);
+        // 编辑模式下计算
         if (!disabled) {
             const height = item.children.reduce(
                 (prev, curr) => prev + weakMap.get(curr).height,
@@ -119,6 +121,7 @@ export const RulesController = <T,>(props: IProps<T>) => {
         namePath: InternalNamePath,
         disabled: boolean
     ) => {
+        // 渲染条件节点和线条
         if (item?.children?.length) {
             const childrenPath = (index: number) => {
                 const newPath = [...namePath];
@@ -177,6 +180,7 @@ export const RulesController = <T,>(props: IProps<T>) => {
                 </div>
             );
         }
+        // 渲染自定义的 component
         return (
             <div className="ruleController__item" key={item.key}>
                 {value?.children && (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as EllipsisText } from './ellipsisText';
 export { default as Empty } from './empty';
 export { default as ErrorBoundary } from './errorBoundary';
 export { default as LoadError } from './errorBoundary/loadError';
+export { default as FilterRules } from './filterRules';
 export { default as Form } from './form';
 export { default as Fullscreen } from './fullscreen';
 export { default as GlobalLoading } from './globalLoading';


### PR DESCRIPTION
#406 

[实现思路](https://luckyfbb.github.io/blog/react/filter-rules)

[Preview](https://luckyfbb.github.io/dt-react-component/components/filter-rules)

实现且或组件
- 组件只希望实现条件节点/线条/操作按钮的展示，因此后面的组件需要作为参数 component 传入
- 组件对层级有一个控制，支持 maxLevel 来控制
- 每一次新增数据的时候，默认值需要传入 initValues
- 支持两种模式 编辑状态 和 查看状态
- 支持受控和非受控两种模式

### 编辑
<img width="1112" alt="image" src="https://github.com/DTStack/dt-react-component/assets/38368040/17137931-3912-4a73-9184-32ea05da060d">

<img width="1096" alt="image" src="https://github.com/DTStack/dt-react-component/assets/38368040/c745ccc8-0452-4fa0-b1c7-638a3e3e6ee9">

### 查看
<img width="1093" alt="image" src="https://github.com/DTStack/dt-react-component/assets/38368040/b2045a22-6b27-40fe-a378-51486a893f7f">

![image](https://github.com/DTStack/dt-react-component/assets/38368040/fb8f319f-a373-487a-894f-d3d963892de2)

![image](https://github.com/DTStack/dt-react-component/assets/38368040/b43a350c-8b51-4ccb-84c2-fe76cc5951a1)