### PR TITLE
feat(slidepane): add footer and extends DrawerProps

### DIFF
--- a/src/resize/index.md
+++ b/src/resize/index.md
@@ -1,12 +1,12 @@
 ---
-title: Resize Resize 事件监听
+title: Resize 事件监听
 group: 组件
 toc: content
 demo:
     cols: 2
 ---
 
-# Resize Resize 事件监听
+# Resize 事件监听
 
 用于监听 window 或者是其他元素的尺寸变化
 

--- a/src/slidePane/__tests/__snapshots__/index.test.tsx.snap
+++ b/src/slidePane/__tests/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`test SlidePane  snapshot match 1`] = `
         />
         <div
           class="dtc-slide-pane-content-wrapper"
-          style="width: 378px;"
+          style="width: 1000px;"
         >
           <div
             aria-modal="true"

--- a/src/slidePane/__tests/index.test.tsx
+++ b/src/slidePane/__tests/index.test.tsx
@@ -1,25 +1,26 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import { alert } from 'ant-design-testing';
 import '@testing-library/jest-dom/extend-expect';
 
 import SlidePane from '../index';
 
 describe('test SlidePane ', () => {
     test('snapshot match', () => {
-        const wrapper = render(<SlidePane visible>Hello World</SlidePane>);
+        const wrapper = render(<SlidePane open>Hello World</SlidePane>);
         expect(wrapper).toMatchSnapshot();
     });
-    test('should be invisible', () => {
-        const { container } = render(<SlidePane visible={false}>Hello World</SlidePane>);
+    test('should be not open', () => {
+        const { container } = render(<SlidePane open={false}>Hello World</SlidePane>);
         expect(container).not.toHaveClass();
     });
     test('should render loading correct ', () => {
-        const { unmount } = render(<SlidePane visible>Hello World</SlidePane>);
+        const { unmount } = render(<SlidePane open>Hello World</SlidePane>);
         const dom = document.querySelector('.ant-spin-spinning');
         expect(dom).toBe(null);
         unmount();
         render(
-            <SlidePane visible loading>
+            <SlidePane open loading>
                 Hello World
             </SlidePane>
         );
@@ -27,12 +28,12 @@ describe('test SlidePane ', () => {
         expect(domLoading).not.toBe(null);
     });
     test('should render mask correct ', () => {
-        const { unmount } = render(<SlidePane visible>Hello World</SlidePane>);
+        const { unmount } = render(<SlidePane open>Hello World</SlidePane>);
         const dom = document.querySelector('.dtc-slide-pane-mask');
         expect(dom).toBe(null);
         unmount();
         render(
-            <SlidePane visible mask>
+            <SlidePane open mask>
                 Hello World
             </SlidePane>
         );
@@ -41,7 +42,7 @@ describe('test SlidePane ', () => {
     });
     test('should render width correct', () => {
         render(
-            <SlidePane visible width={640}>
+            <SlidePane open width={640}>
                 Hello World
             </SlidePane>
         );
@@ -49,10 +50,20 @@ describe('test SlidePane ', () => {
             width: '640px',
         });
     });
+    test('should render size width correct', () => {
+        render(
+            <SlidePane open size="large">
+                Hello World
+            </SlidePane>
+        );
+        expect(document.querySelector('.dtc-slide-pane-content-wrapper')).toHaveStyle({
+            width: '1256px',
+        });
+    });
     test('should render className/style correct', () => {
         const { unmount } = render(
             <SlidePane
-                visible
+                open
                 rootClassName="root-className"
                 bodyClassName="body-className"
                 rootStyle={{ color: 'red' }}
@@ -72,7 +83,7 @@ describe('test SlidePane ', () => {
     test('should render tab correct', () => {
         const { getByText, unmount } = render(
             <SlidePane
-                visible
+                open
                 width={640}
                 tabs={[
                     { key: '1', title: 'tab1' },
@@ -98,7 +109,7 @@ describe('test SlidePane ', () => {
 
         const { getByText: getByText1 } = render(
             <SlidePane
-                visible
+                open
                 width={640}
                 tabs={[
                     { key: '1', title: 'tab1' },
@@ -121,10 +132,38 @@ describe('test SlidePane ', () => {
         expect(getByText1('变更记录')).toBeTruthy();
         expect(getByText1('tab2').parentNode).toHaveClass('ant-tabs-tab-active');
     });
+    test('Should support string banner', async () => {
+        const { getByText } = render(
+            <SlidePane open banner="banner">
+                Hello World
+            </SlidePane>
+        );
+
+        expect(getByText('banner')).toBeInTheDocument();
+    });
+    test('Should support ReactNode', async () => {
+        const { getByTestId } = render(
+            <SlidePane open banner={<div data-testid="banner">xxxx</div>}>
+                test
+            </SlidePane>
+        );
+
+        expect(getByTestId('banner')).toBeInTheDocument();
+    });
+    it('Should support AlertProps', async () => {
+        const { getByText } = render(
+            <SlidePane open banner={{ message: 'banner', type: 'error' }}>
+                test
+            </SlidePane>
+        );
+
+        expect(getByText('banner')).toBeInTheDocument();
+        expect(alert.query(document)?.classList.contains('ant-alert-error')).toBeTruthy();
+    });
     test('should callback to be called', () => {
         const fn = jest.fn();
         const { getByRole } = render(
-            <SlidePane visible onClose={fn}>
+            <SlidePane open onClose={fn}>
                 Hello World
             </SlidePane>
         );

--- a/src/slidePane/demos/basicBanner.tsx
+++ b/src/slidePane/demos/basicBanner.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Button } from 'antd';
+import { SlidePane } from 'dt-react-component';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <>
+            <Button style={{ margin: '10px' }} onClick={() => setVisible((v) => !v)}>
+                click me
+            </Button>
+            <SlidePane
+                open={visible}
+                banner="这是 SlidePane 的 banner"
+                onClose={() => setVisible(false)}
+                title="title"
+            >
+                <div>hello world</div>
+            </SlidePane>
+        </>
+    );
+};

--- a/src/slidePane/demos/basicBannerProps.tsx
+++ b/src/slidePane/demos/basicBannerProps.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { Button } from 'antd';
+import { SlidePane } from 'dt-react-component';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <>
+            <Button style={{ margin: '10px' }} onClick={() => setVisible((v) => !v)}>
+                click me
+            </Button>
+            <SlidePane
+                open={visible}
+                banner={{
+                    message: 'SlidePane 可以支持 banner 属性',
+                    type: 'error',
+                    showIcon: true,
+                }}
+                onClose={() => setVisible(false)}
+                title="title"
+            >
+                <div>hello world</div>
+            </SlidePane>
+        </>
+    );
+};

--- a/src/slidePane/demos/basicSize.tsx
+++ b/src/slidePane/demos/basicSize.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Button, Space } from 'antd';
+import { SlidePane } from 'dt-react-component';
+import { SlidePaneProps } from 'dt-react-component/slidePane';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+    const [size, setSize] = useState<SlidePaneProps<[]>['size']>('default');
+
+    return (
+        <>
+            <Space>
+                <Button
+                    type="primary"
+                    onClick={() => {
+                        setVisible(true);
+                        setSize('small');
+                    }}
+                >
+                    小尺寸
+                </Button>
+                <Button
+                    type="primary"
+                    onClick={() => {
+                        setVisible(true);
+                        setSize('default');
+                    }}
+                >
+                    正常尺寸
+                </Button>
+                <Button
+                    type="primary"
+                    onClick={() => {
+                        setVisible(true);
+                        setSize('large');
+                    }}
+                >
+                    大尺寸
+                </Button>
+            </Space>
+            <SlidePane open={visible} size={size} onClose={() => setVisible(false)} title="title">
+                <div>hello world</div>
+            </SlidePane>
+        </>
+    );
+};

--- a/src/slidePane/demos/basic_mask.tsx
+++ b/src/slidePane/demos/basic_mask.tsx
@@ -19,7 +19,7 @@ export default () => {
                 click me
             </Button>
             <SlidePane
-                visible={visible}
+                open={visible}
                 rootStyle={{
                     minHeight: '600px',
                     height: '100%',

--- a/src/slidePane/demos/basic_top.tsx
+++ b/src/slidePane/demos/basic_top.tsx
@@ -1,39 +1,26 @@
 import React, { useState } from 'react';
-import { Button, Slider } from 'antd';
+import { Alert, Button } from 'antd';
 import { SlidePane } from 'dt-react-component';
 
 export default () => {
     const [visible, setVisible] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [width, setWidth] = useState(80);
 
     return (
         <>
-            <Slider
-                defaultValue={width}
-                min={10}
-                max={100}
-                onChange={(value: number) => setWidth(value)}
-            />
-            <span>width:{width}%</span>
+            <Alert message="产品中抽屉的距离顶部高度 64px，可通过 rootStyle 设置" />
             <Button
                 style={{ margin: '10px' }}
                 onClick={() => {
                     setVisible((v) => !v);
-                    setLoading(true);
-                    setTimeout(() => {
-                        setLoading(false);
-                    }, 3000);
                 }}
             >
                 click me
             </Button>
             <SlidePane
                 open={visible}
-                loading={loading}
-                width={`${width}%`}
                 onClose={() => setVisible(false)}
                 title="title"
+                rootStyle={{ top: 64 }}
             >
                 <div>hello world</div>
             </SlidePane>

--- a/src/slidePane/demos/customTitle.tsx
+++ b/src/slidePane/demos/customTitle.tsx
@@ -9,7 +9,7 @@ export default () => {
         <>
             <Button onClick={() => setVisible(true)}>打开</Button>
             <SlidePane
-                visible={visible}
+                open={visible}
                 rootStyle={{
                     minHeight: '600px',
                     height: '100%',

--- a/src/slidePane/demos/footer.tsx
+++ b/src/slidePane/demos/footer.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import { Button, Space } from 'antd';
+import { SlidePane } from 'dt-react-component';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setVisible(true)}>打开</Button>
+            <SlidePane
+                open={visible}
+                onClose={() => setVisible(false)}
+                title="Title"
+                footer={
+                    <Space>
+                        <Button>重置</Button>
+                        <Button type="primary">立即执行</Button>
+                    </Space>
+                }
+            >
+                <div style={{ height: '110vh' }}>超长可滚动</div>
+            </SlidePane>
+        </>
+    );
+};

--- a/src/slidePane/demos/tabs.tsx
+++ b/src/slidePane/demos/tabs.tsx
@@ -9,7 +9,7 @@ export default () => {
         <>
             <Button onClick={() => setVisible(true)}>打开</Button>
             <SlidePane
-                visible={visible}
+                open={visible}
                 onClose={() => setVisible(false)}
                 title={'Title'}
                 tabs={

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -17,22 +17,31 @@ demo:
 
 <code src="./demos/basic.tsx" title="基础使用"></code>
 <code src="./demos/basic_mask.tsx" title="基础 mask 使用"></code>
+<code src="./demos/basicSize.tsx" title="尺寸"></code>
 <code src="./demos/basic_top.tsx" title="抽屉距顶部高度"></code>
 <code src="./demos/customTitle.tsx" title="自定义 Title"></code>
 <code src="./demos/tabs.tsx" title="展示 tabs"></code>
 <code src="./demos/footer.tsx" title="展示 footer"></code>
+<code src="./demos/basicBanner.tsx" title="支持 banner"></code>
+<code src="./demos/basicBannerProps.tsx" title="支持传 banner 的 Props 属性"></code>
 
 ## API
 
-| 参数          | 说明                           | 类型                                                  | 默认值 |
-| ------------- | ------------------------------ | ----------------------------------------------------- | ------ |
-| title         | 右侧面板的 title               | `React.ReactNode`                                     | -      |
-| children      | 右侧面板展示内容               | `(key: string) => React.ReactNode \| React.ReactNode` | -      |
-| tabs          | 右侧面板的内容的 Tabs          | `{ key: string; title: React.ReactNode }[]`           | -      |
-| activeKeys    | 右侧面板的内容的 Tabs 的选中项 | `string`                                              | -      |
-| bodyClassName | 内容容器的类名                 | `string`                                              | -      |
-| bodyStyle     | 内容容器的样式                 | `CSSProperties`                                       | -      |
-| footer        | 右侧面板的底部内容             | `React.ReactNode`                                     | -      |
+### AlertProps
+
+[AlertProps](https://4x-ant-design.antgroup.com/components/alert-cn/#API)
+
+| 参数          | 说明                           | 类型                                                  | 默认值    |
+| ------------- | ------------------------------ | ----------------------------------------------------- | --------- |
+| activeKeys    | 右侧面板的内容的 Tabs 的选中项 | `string`                                              | -         |
+| banner        | 提示                           | `React.ReactNode \| AlertProps`                       | -         |
+| bodyClassName | 内容容器的类名                 | `string`                                              | -         |
+| bodyStyle     | 内容容器的样式                 | `CSSProperties`                                       | -         |
+| children      | 右侧面板展示内容               | `(key: string) => React.ReactNode \| React.ReactNode` | -         |
+| footer        | 右侧面板的底部内容             | `React.ReactNode`                                     | -         |
+| size          | 尺寸                           | `'small' \| 'default' \| 'large'`                     | `default` |
+| tabs          | 右侧面板的内容的 Tabs          | `{ key: string; title: React.ReactNode }[]`           | -         |
+| title         | 右侧面板的 title               | `React.ReactNode`                                     | -         |
 
 :::info
 其余属性继承 [antd4.x 的 Drawer](https://4x.ant.design/components/drawer-cn/#API)

--- a/src/slidePane/index.md
+++ b/src/slidePane/index.md
@@ -17,22 +17,23 @@ demo:
 
 <code src="./demos/basic.tsx" title="基础使用"></code>
 <code src="./demos/basic_mask.tsx" title="基础 mask 使用"></code>
+<code src="./demos/basic_top.tsx" title="抽屉距顶部高度"></code>
 <code src="./demos/customTitle.tsx" title="自定义 Title"></code>
 <code src="./demos/tabs.tsx" title="展示 tabs"></code>
+<code src="./demos/footer.tsx" title="展示 footer"></code>
 
 ## API
 
 | 参数          | 说明                           | 类型                                                  | 默认值 |
 | ------------- | ------------------------------ | ----------------------------------------------------- | ------ |
-| visible       | SlidePanel 是否可见            | `boolean`                                             | -      |
 | title         | 右侧面板的 title               | `React.ReactNode`                                     | -      |
-| mask          | 是否展示遮罩层                 | `boolean`                                             | false  |
-| width         | 右侧面板的宽度                 | `number \| string`                                    | -      |
 | children      | 右侧面板展示内容               | `(key: string) => React.ReactNode \| React.ReactNode` | -      |
 | tabs          | 右侧面板的内容的 Tabs          | `{ key: string; title: React.ReactNode }[]`           | -      |
 | activeKeys    | 右侧面板的内容的 Tabs 的选中项 | `string`                                              | -      |
-| rootClassName | 右侧面板外层容器的类名         | `string`                                              | -      |
 | bodyClassName | 内容容器的类名                 | `string`                                              | -      |
-| rootStyle     | 右侧面板内部容器的样式         | `CSSProperties`                                       | -      |
 | bodyStyle     | 内容容器的样式                 | `CSSProperties`                                       | -      |
-| onClose       | 关闭回调                       | `function`                                            | -      |
+| footer        | 右侧面板的底部内容             | `React.ReactNode`                                     | -      |
+
+:::info
+其余属性继承 [antd4.x 的 Drawer](https://4x.ant.design/components/drawer-cn/#API)
+:::

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -133,9 +133,7 @@ const SlidePane = <T extends readOnlyTab>(props: SlidePaneProps<T>) => {
                     {typeof children === 'function' ? children(tabKey) : children}
                 </div>
                 {footer ? (
-                    <div className={classNames(`${slidePrefixCls}-footer`, bodyClassName)}>
-                        {footer}
-                    </div>
+                    <div className={classNames(`${slidePrefixCls}-footer`)}>{footer}</div>
                 ) : null}
             </Spin>
         </RcDrawer>

--- a/src/slidePane/index.tsx
+++ b/src/slidePane/index.tsx
@@ -80,7 +80,7 @@ const SlidePane = <T extends readOnlyTab>(props: SlidePaneProps<T>) => {
         composeOpen &&
             isFunction(props) &&
             setTabKey(props.activeKey || props.tabs?.[0]?.key || '');
-    }, [open, visible]);
+    }, [composeOpen]);
 
     const renderButton = () => {
         return (

--- a/src/slidePane/style.scss
+++ b/src/slidePane/style.scss
@@ -1,7 +1,7 @@
 $prefix: "dtc-slide-pane";
 
 .#{$prefix} {
-    top: 64px;
+    top: 0;
     bottom: 0;
     left: 0;
     right: 0;
@@ -66,6 +66,14 @@ $prefix: "dtc-slide-pane";
         padding: 16px;
         overflow-y: scroll;
     }
+    &-footer {
+        height: 56px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding-right: 16px;
+        border-top: 1px solid #EBECF0;
+    }
     &-icon {
         width: 12px;
         height: 56px;
@@ -79,6 +87,8 @@ $prefix: "dtc-slide-pane";
         height: 100%;
         .ant-spin-container {
             height: 100%;
+            display: flex;
+            flex-direction: column;
         }
     }
 }


### PR DESCRIPTION
1. 支持传入 footer 属性，Drawer 底部的按钮操作
2. header 和 footer 固定，中间内容 content 超出高度滚动(包含 padding)
3. 继承 DrawerProps 修改 ts 类型。将 visible 改为 deprecated，支持 open
4. 删除默认的距离顶部 64px，支持通过 rootstyle 修改，例子 **抽屉距顶部高度** (目前产品都是用 64px)
5. 支持 banner 属性，类似 RC modal 上的 banner
6. 支持 size 属性，`small | default | large`，width 优先级更高

#437 

[Previewer](https://luckyfbb.github.io/dt-react-component/components/slide-pane)