### PR TITLE
fix(blockheader): #471, add tooltip icon size 16 and change color

### DIFF
--- a/src/components/blockHeader/index.tsx
+++ b/src/components/blockHeader/index.tsx
@@ -53,7 +53,7 @@ const BlockHeader: React.FC<BlockHeaderProps> = function (props) {
     const { beforeTitle = <div className={`default ${isSmall ? 'small' : ''}`}></div> } = props;
     const questionTooltip = tooltip && (
         <Tooltip title={tooltip}>
-            <QuestionCircleOutlined />
+            <QuestionCircleOutlined className={`${prefixCls}-after-title-icon`} />
         </Tooltip>
     );
     const newAfterTitle = afterTitle || questionTooltip;

--- a/src/components/blockHeader/style.scss
+++ b/src/components/blockHeader/style.scss
@@ -57,8 +57,14 @@ $card_prefix: "dtc-block-header";
                 margin-right: 4px;
             }
             .#{$card_prefix}-after-title {
+                display: flex;
+                align-items: center;
                 color: #8B8FA8;
                 font-size: 12px;
+                &-icon {
+                    font-size: 16px;
+                    color: #B1B4C5;
+                }
             }
         }
 


### PR DESCRIPTION
#### 变更类型

请选择以下选项以描述 PR 的类型：

- [x] Bug 修复（修复现有问题）
- [ ] 新功能（添加了一个功能）
- [ ] 代码优化（性能改进、代码重构）
- [ ] 文档更新
- [ ] 单测新增或修改
- [ ] 其他（请说明）：

#### 相关问题
#471 

#### 变更内容
3.x 版本 blockheader tooltip 的 icon 样式不对

修改 icon size为 16px，颜色为 b1b4c5

#### 详细描述

#### 对应 Previewer

before
<img width="206" alt="image" src="https://github.com/user-attachments/assets/d5a9d042-b8c6-452b-ad2f-f3845a8e01ee">

after
<img width="215" alt="image" src="https://github.com/user-attachments/assets/763a0313-8dfe-4e02-8e12-ee6a29198cf3">




