### PR TITLE
fix(blockheader): fix spaceBottom when expand

### DIFF
--- a/src/blockHeader/index.tsx
+++ b/src/blockHeader/index.tsx
@@ -86,7 +86,9 @@ const BlockHeader: React.FC<IBlockHeaderProps> = function (props) {
     const tooltipProps = toTooltipProps(tooltip);
 
     let bottomStyle;
-    if (spaceBottom) bottomStyle = { marginBottom: spaceBottom };
+    if (spaceBottom)
+        bottomStyle =
+            showCollapse && currentExpand ? { marginBottom: 0 } : { marginBottom: spaceBottom };
 
     const handleExpand = (expand: boolean) => {
         if (!children) return;


### PR DESCRIPTION
#### 变更类型

请选择以下选项以描述 PR 的类型：

- [x] Bug 修复（修复现有问题）
- [ ] 新功能（添加了一个功能）
- [ ] 代码优化（性能改进、代码重构）
- [ ] 文档更新
- [ ] 单测新增或修改
- [ ] 其他（请说明）：

#### 相关问题
#490

#### 变更内容
如果 BlockHeader 打开的时候，marginBottom 展示为0，使用 children 的 padding，否则两者相加会导致问题

#### 详细描述
之前：
![chatgpt](https://github.com/user-attachments/assets/3fc4b3e9-3d68-4df2-9b44-9f4aa2dcb252)

现在：
![chatgpt](https://github.com/user-attachments/assets/e196ce63-4661-4ce0-bcc1-8d435ebece3d)


#### 对应 Previewer



