### PR TITLE
fix(tinyTag): via getComputedTextLength api to measure svg text element

### DIFF
--- a/src/tinyTag/index.tsx
+++ b/src/tinyTag/index.tsx
@@ -18,7 +18,7 @@ const useSvgWidth = (): UseSvgWidthResult => {
     const getWidth = useCallback(() => {
         if (!element) return;
         const paddingWidth = 8;
-        const textWidth = Math.round(element.getBoundingClientRect()?.width);
+        const textWidth = Math.round(element.getComputedTextLength?.() ?? 0);
         const svgWidth = textWidth + paddingWidth;
         setSvgWidth(svgWidth);
         setRectWidth(Math.max(svgWidth - 1, 0));


### PR DESCRIPTION
#### 变更类型

请选择以下选项以描述 PR 的类型：

- [x] Bug 修复（修复现有问题）
- [ ] 新功能（添加了一个功能）
- [ ] 代码优化（性能改进、代码重构）
- [ ] 文档更新
- [ ] 单测新增或修改
- [ ] 其他（请说明）：

#### 相关问题
1. #630


#### 变更内容
1. 修复 TinyTag 宽度计算问题(使用 getBoundingClientRect 在模态框中，计算出的宽度有随机性)
2. 历史记录可在内部 MR 搜索 #142827，查看 jialan 的 MR

#### 详细描述


#### 对应 Previewer



