### PR TITLE
feat(tinytag): support width remeasurement for hidden tag

### DIFF
--- a/src/tinyTag/__tests__/__snapshots__/tinyTag.test.tsx.snap
+++ b/src/tinyTag/__tests__/__snapshots__/tinyTag.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`test StatusTag should match snapshot 1`] = `
     <svg
       fill="none"
       height="15"
-      viewBox="0 0 8 15"
-      width="8"
+      viewBox="0 0 28 15"
+      width="28"
       xmlns="http://www.w3.org/2000/svg"
     >
       <rect
@@ -18,7 +18,7 @@ exports[`test StatusTag should match snapshot 1`] = `
         rx="1.5"
         stroke="currentColor"
         stroke-linejoin="bevel"
-        width="7"
+        width="27"
         x="0.5"
         y="0.5"
       />
@@ -48,8 +48,8 @@ exports[`test StatusTag should support fill type 1`] = `
     <svg
       fill="none"
       height="15"
-      viewBox="0 0 8 15"
-      width="8"
+      viewBox="0 0 28 15"
+      width="28"
       xmlns="http://www.w3.org/2000/svg"
     >
       <rect
@@ -58,7 +58,7 @@ exports[`test StatusTag should support fill type 1`] = `
         rx="1.5"
         stroke="#D56161"
         stroke-linejoin="bevel"
-        width="7"
+        width="27"
         x="0.5"
         y="0.5"
       />

--- a/src/tinyTag/__tests__/tinyTag.test.tsx
+++ b/src/tinyTag/__tests__/tinyTag.test.tsx
@@ -5,7 +5,36 @@ import '@testing-library/jest-dom/extend-expect';
 import TinyTag from '..';
 
 describe('test StatusTag', () => {
-    beforeEach(cleanup);
+    const svgElementPrototype = SVGElement.prototype as SVGElement & {
+        getComputedTextLength?: () => number;
+    };
+    const getComputedTextLength = svgElementPrototype.getComputedTextLength;
+    const requestAnimationFrame = window.requestAnimationFrame;
+    const cancelAnimationFrame = window.cancelAnimationFrame;
+
+    beforeEach(() => {
+        cleanup();
+        Object.defineProperty(svgElementPrototype, 'getComputedTextLength', {
+            configurable: true,
+            value: jest.fn(() => 20),
+        });
+        window.requestAnimationFrame = jest.fn((callback) => {
+            callback(0);
+            return 0;
+        });
+        window.cancelAnimationFrame = jest.fn();
+    });
+
+    afterEach(() => {
+        cleanup();
+        Object.defineProperty(svgElementPrototype, 'getComputedTextLength', {
+            configurable: true,
+            value: getComputedTextLength,
+        });
+        window.requestAnimationFrame = requestAnimationFrame;
+        window.cancelAnimationFrame = cancelAnimationFrame;
+        jest.useRealTimers();
+    });
 
     test('should match snapshot', () => {
         const { asFragment } = render(<TinyTag value="完成" className="dtc-test" />);
@@ -17,6 +46,16 @@ describe('test StatusTag', () => {
             <TinyTag value="完成" type="fill" bgColor="#D56161" color="#fff" />
         );
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    test('should remeasure width after hidden render', () => {
+        const measureWidth = svgElementPrototype.getComputedTextLength as jest.Mock;
+        measureWidth.mockReturnValueOnce(0).mockReturnValue(24);
+
+        const { container } = render(<TinyTag value="META" />);
+
+        expect(container.querySelector('svg')?.getAttribute('width')).toBe('32');
+        expect(container.querySelector('rect')?.getAttribute('width')).toBe('31');
     });
 
     test('should render custom color in default mode', () => {

--- a/src/tinyTag/demos/hidden.tsx
+++ b/src/tinyTag/demos/hidden.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { Button, Space } from 'antd';
+import { TinyTag } from 'dt-react-component';
+
+export default () => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <Space direction="vertical" size={8}>
+            <Button type="primary" onClick={() => setVisible(!visible)}>
+                {visible ? '隐藏标签' : '显示标签'}
+            </Button>
+            <div style={{ display: visible ? 'block' : 'none' }}>
+                <TinyTag value="隐藏渲染后显示的标签" />
+            </div>
+        </Space>
+    );
+};

--- a/src/tinyTag/index.md
+++ b/src/tinyTag/index.md
@@ -13,6 +13,7 @@ TinyTag 组件通常用于在某些文案后面，用于标识当前行数据的
 ## 示例
 
 <code src="./demos/basic.tsx">基础使用</code>
+<code src="./demos/hidden.tsx">隐藏渲染</code>
 <code src="./demos/table.tsx">表格使用</code>
 
 ## API

--- a/src/tinyTag/index.tsx
+++ b/src/tinyTag/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import classNames from 'classnames';
 
 import './style.scss';
@@ -29,17 +29,37 @@ const useSvgWidth = (): UseSvgWidthResult => {
     const [rectWidth, setRectWidth] = useState(0);
 
     const getWidth = useCallback(() => {
-        if (!element) return;
+        if (!element) return false;
         const paddingWidth = 8;
-        const textWidth = Math.round(element.getComputedTextLength?.() ?? 0);
+        const textWidth = Math.round(element.getComputedTextLength());
+        if (!textWidth) return false;
         const svgWidth = textWidth + paddingWidth;
         setSvgWidth(svgWidth);
         setRectWidth(Math.max(svgWidth - 1, 0));
+        return true;
     }, [element]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         getWidth();
-    }, [element]);
+        const timer = window.requestAnimationFrame(getWidth);
+
+        return () => {
+            window.cancelAnimationFrame(timer);
+        };
+    }, [getWidth]);
+
+    useEffect(() => {
+        if (!element || !window.ResizeObserver) return undefined;
+
+        const resizeObserver = new window.ResizeObserver(() => {
+            getWidth();
+        });
+        resizeObserver.observe(element);
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [element, getWidth]);
 
     return [ref, svgWidth, rectWidth];
 };


### PR DESCRIPTION
#### 变更类型

请选择以下选项以描述 PR 的类型：

- [x] Bug 修复（修复现有问题）
- [ ] 新功能（添加了一个功能）
- [ ] 代码优化（性能改进、代码重构）
- [ ] 文档更新
- [ ] 单测新增或修改
- [ ] 其他（请说明）：

#### 相关问题
#648

#### 变更内容
改动点：TinyTag 组件新增对隐藏渲染场景下宽度动态重算的支持。通过 ResizeObserver 和 requestAnimationFrame 监听 SVG
  文本元素尺寸与可见性变化，解决隐藏节点重新显示时宽度测量不准确的问题，并更新了隐藏渲染 Demo 与单元测试。

影响范围：TinyTag 组件在隐藏/延迟展示容器（如 Modal、Drawer、Tab、折叠面板等）中的文本宽度计算与排版渲染。常规直接渲染场景保持兼容。

#### 详细描述


#### 对应 Previewer



